### PR TITLE
Remove `split_default` integration tests

### DIFF
--- a/tests/pica/split.rs
+++ b/tests/pica/split.rs
@@ -6,33 +6,6 @@ use std::fs::{read_to_string, remove_file};
 use tempfile::Builder;
 
 #[test]
-fn split_default() -> MatchResult {
-    CommandBuilder::new("split")
-        .arg("-s")
-        .arg("1")
-        .arg("tests/data/dump.dat.gz")
-        .with_stdout_empty()
-        .run()?;
-
-    let expected = [
-        // ("0.dat", SAMPLE1), (see https://git.io/JZmHJ)
-        ("1.dat", SAMPLE2),
-        ("2.dat", SAMPLE3),
-        ("3.dat", SAMPLE4),
-        ("4.dat", SAMPLE5),
-        ("5.dat", SAMPLE6),
-        ("6.dat", SAMPLE7),
-    ];
-
-    for (filename, sample) in expected.iter() {
-        assert_eq!(read_to_string(filename).unwrap(), *sample);
-        remove_file(filename).unwrap();
-    }
-
-    Ok(())
-}
-
-#[test]
 fn split_outdir() -> MatchResult {
     let tempdir = Builder::new().prefix("pica-split").tempdir().unwrap();
     let outdir = tempdir.path();


### PR DESCRIPTION
The `split_default` integration tests panics sporadically, because of parallel execution. If the `--test-threads` option is set to `1` everything is fine. Instead of disable the parallel execution, the test is removed because the `split_outdir` test covers the same functionality.

Closes #224