### PR TITLE
README: PICA3 => PICA Plain

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ outdir
 ### Print
 
 The `print` command is used to print records in a human-readable format. The
-format is similar to PICA3.
+format is similar to [PICA Plain](http://format.gbv.de/pica/plain).
 
 ```bash
 $ echo -e "003@ \x1f0123456789\x1fab\x1e" | pica print


### PR DESCRIPTION
The print command uses a custom format similar to PICA Plain with additional space after each subfield code. I guess that `$` in a subfield value is not escaped as `$$` like it is in PICA Plain.