### PR TITLE
Add `xml` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ sophia_api = "0.7"
 strsim = "0.10"
 termcolor = "1.1"
 toml = "0.5"
+xml-rs = "0.8"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/README.md
+++ b/README.md
@@ -32,19 +32,20 @@ $ cargo install --git https://github.com/deutsche-nationalbibliothek/pica-rs --t
 
 ## Commands
 
-| Command                 | Stability | Desciption                                           |
-|-------------------------|-----------|------------------------------------------------------|
-| [cat](#cat)             | beta      | concatenate records from multiple files              |
-| completion              | beta      | generate a completions file for bash, fish or zsh    |
-| [filter](#filter)       | beta      | filter records by query expressions                  |
-| [frequency](#frequency) | beta      | compute a frequency table of a subfield              |
-| invalid                 | beta      | filter out invalid records                           |
-| [partition](#partition) | beta      | partition a list of records based on subfield values |
-| [print](#print)         | beta      | print records in human readable format               |
-| [sample](#sample)       | beta      | selects a random permutation of records              |
-| [select](#select)       | beta      | write subfields to a CSV file                        |
-| [slice](#slice)         | beta      | return records withing a range (half-open interval)  |
-| [split](#split)         | beta      | split a list of records into chunks                  |
+| Command                 | Stability | Desciption                                                        |
+|-------------------------|-----------|-------------------------------------------------------------------|
+| [cat](#cat)             | beta      | concatenate records from multiple files                           |
+| completion              | beta      | generate a completions file for bash, fish or zsh                 |
+| [filter](#filter)       | beta      | filter records by query expressions                               |
+| [frequency](#frequency) | beta      | compute a frequency table of a subfield                           |
+| invalid                 | beta      | filter out invalid records                                        |
+| [partition](#partition) | beta      | partition a list of records based on subfield values              |
+| [print](#print)         | beta      | print records in human readable format                            |
+| [sample](#sample)       | beta      | selects a random permutation of records                           |
+| [select](#select)       | beta      | write subfields to a CSV file                                     |
+| [slice](#slice)         | beta      | return records withing a range (half-open interval)               |
+| [split](#split)         | beta      | split a list of records into chunks                               |
+| [xml](#xml)             | unstable  | serialize records into [PICA XML](https://format.gbv.de/pica/xml) |
 
 ## Usage
 
@@ -245,6 +246,23 @@ outdir
 ├── CHUNK_0.dat
 ├── CHUNK_10.dat
 ├── ...
+```
+
+### XML
+
+The `xml` command converts records into the [PICA XML](https://format.gbv.de/pica/xml) format.
+More information can be found in the [GBV Wiki](https://verbundwiki.gbv.de/display/VZG/PICA+XML+Version+1.0).
+
+```
+$ echo -e "003@ \x1f0123456789\x1fab\x1e" | pica xml
+<?xml version="1.0" encoding="utf-8"?>
+<collection xmlns="info:srw/schema/5/picaXML-v1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="info:srw/schema/5/picaXML-v1.0">
+  <record>
+    <datafield tag="003@">
+      <subfield code="0">123456789</subfield>
+    </datafield>
+  </record>
+</collection>
 ```
 
 ## Related Projects

--- a/src/bin/pica/cmds/mod.rs
+++ b/src/bin/pica/cmds/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod sample;
 pub(crate) mod select;
 pub(crate) mod slice;
 pub(crate) mod split;
+pub(crate) mod xml;
 
 use crate::util::App;
 
@@ -27,5 +28,6 @@ pub(crate) fn subcmds() -> Vec<App> {
         select::cli(),
         slice::cli(),
         split::cli(),
+        xml::cli(),
     ]
 }

--- a/src/bin/pica/cmds/print.rs
+++ b/src/bin/pica/cmds/print.rs
@@ -113,7 +113,7 @@ pub(crate) fn run(args: &CliArgs, config: &Config) -> CliResult<()> {
 
                 // OCCURRENCE
                 if let Some(occurrence) = field.occurrence() {
-                    write!(&mut stdout, "{}", occurrence)?;
+                    write!(&mut stdout, "/{}", occurrence)?;
                 }
 
                 if !add_spaces {

--- a/src/bin/pica/cmds/xml.rs
+++ b/src/bin/pica/cmds/xml.rs
@@ -1,0 +1,100 @@
+use crate::config::Config;
+use crate::skip_invalid_flag;
+use crate::util::{App, CliArgs, CliResult};
+use clap::Arg;
+use pica::ReaderBuilder;
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::{self, Write};
+use xml::writer::XmlEvent;
+use xml::EmitterConfig;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct XmlConfig {
+    pub(crate) skip_invalid: Option<bool>,
+    pub(crate) gzip: Option<bool>,
+}
+
+pub(crate) fn cli() -> App {
+    App::new("xml")
+        .about("Serialize records to PICA XML")
+        .arg(
+            Arg::new("skip-invalid")
+                .short('s')
+                .long("skip-invalid")
+                .about("skip invalid records"),
+        )
+        .arg(
+            Arg::new("output")
+                .short('o')
+                .long("--output")
+                .value_name("file")
+                .about("Write output to <file> instead of stdout."),
+        )
+        .arg(Arg::new("filename"))
+}
+
+pub(crate) fn run(args: &CliArgs, config: &Config) -> CliResult<()> {
+    let skip_invalid = skip_invalid_flag!(args, config.xml, config.global);
+
+    let mut reader = ReaderBuilder::new()
+        .skip_invalid(skip_invalid)
+        .from_path_or_stdin(args.value_of("filename"))?;
+
+    let mut writer: Box<dyn Write> = match args.value_of("output") {
+        Some(filename) => Box::new(File::create(filename)?),
+        None => Box::new(io::stdout()),
+    };
+
+    let mut xml_writer = EmitterConfig::new()
+        .perform_indent(true)
+        .normalize_empty_elements(true)
+        .pad_self_closing(true)
+        .create_writer(&mut writer);
+
+    xml_writer.write(
+        XmlEvent::start_element("collection")
+            .ns("xs", "http://www.w3.org/2001/XMLSchema")
+            .attr("targetNamespace", "info:srw/schema/5/picaXML-v1.0")
+            .default_ns("info:srw/schema/5/picaXML-v1.0"),
+    )?;
+
+    for result in reader.records() {
+        let record = result?;
+
+        xml_writer.write(
+            XmlEvent::start_element("record")
+                .default_ns("info:srw/schema/5/picaXML-v1.0"),
+        )?;
+
+        for field in record.iter() {
+            xml_writer.write(
+                XmlEvent::start_element("datafield")
+                    .attr("tag", &field.tag().to_string()),
+            )?;
+
+            for subfield in field.iter() {
+                xml_writer.write(
+                    XmlEvent::start_element("subfield")
+                        .attr("code", &subfield.code().to_string()),
+                )?;
+
+                xml_writer.write(XmlEvent::characters(
+                    &subfield.value().to_string(),
+                ))?;
+
+                xml_writer.write(XmlEvent::end_element())?;
+            }
+
+            xml_writer.write(XmlEvent::end_element())?;
+        }
+
+        xml_writer.write(XmlEvent::end_element())?;
+    }
+
+    xml_writer.write(XmlEvent::end_element())?;
+    writer.flush()?;
+
+    Ok(())
+}

--- a/src/bin/pica/cmds/xml.rs
+++ b/src/bin/pica/cmds/xml.rs
@@ -69,10 +69,18 @@ pub(crate) fn run(args: &CliArgs, config: &Config) -> CliResult<()> {
         )?;
 
         for field in record.iter() {
-            xml_writer.write(
-                XmlEvent::start_element("datafield")
-                    .attr("tag", &field.tag().to_string()),
-            )?;
+            if let Some(occurrence) = field.occurrence() {
+                xml_writer.write(
+                    XmlEvent::start_element("datafield")
+                        .attr("tag", &field.tag().to_string())
+                        .attr("occurrence", &occurrence.to_string()),
+                )?;
+            } else {
+                xml_writer.write(
+                    XmlEvent::start_element("datafield")
+                        .attr("tag", &field.tag().to_string()),
+                )?;
+            }
 
             for subfield in field.iter() {
                 xml_writer.write(

--- a/src/bin/pica/config.rs
+++ b/src/bin/pica/config.rs
@@ -24,6 +24,7 @@ pub(crate) struct Config {
     pub(crate) select: Option<crate::cmds::select::SelectConfig>,
     pub(crate) slice: Option<crate::cmds::slice::SliceConfig>,
     pub(crate) split: Option<crate::cmds::split::SplitConfig>,
+    pub(crate) xml: Option<crate::cmds::xml::XmlConfig>,
 }
 
 impl Config {

--- a/src/bin/pica/main.rs
+++ b/src/bin/pica/main.rs
@@ -37,6 +37,7 @@ fn run() -> CliResult<()> {
         "select" => cmds::select::run(args, &config),
         "slice" => cmds::slice::run(args, &config),
         "split" => cmds::split::run(args, &config),
+        "xml" => cmds::xml::run(args, &config),
         _ => unreachable!(),
     }
 }
@@ -64,6 +65,10 @@ fn main() {
         }
         Err(CliError::Csv(err)) => {
             eprintln!("CSV Error: {}", err);
+            process::exit(1);
+        }
+        Err(CliError::Xml(err)) => {
+            eprintln!("XML Error: {}", err);
             process::exit(1);
         }
         Err(CliError::Other(err)) => {

--- a/src/bin/pica/util.rs
+++ b/src/bin/pica/util.rs
@@ -9,6 +9,7 @@ pub(crate) type CliResult<T> = Result<T, CliError>;
 pub(crate) enum CliError {
     Io(io::Error),
     Csv(csv::Error),
+    Xml(xml::writer::Error),
     Pica(pica::Error),
     Other(String),
 }
@@ -17,6 +18,7 @@ impl fmt::Display for CliError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             CliError::Csv(ref e) => e.fmt(f),
+            CliError::Xml(ref e) => e.fmt(f),
             CliError::Io(ref e) => e.fmt(f),
             CliError::Pica(ref e) => e.fmt(f),
             CliError::Other(ref s) => f.write_str(&**s),
@@ -39,5 +41,11 @@ impl From<io::Error> for CliError {
 impl From<csv::Error> for CliError {
     fn from(err: csv::Error) -> CliError {
         CliError::Csv(err)
+    }
+}
+
+impl From<xml::writer::Error> for CliError {
+    fn from(err: xml::writer::Error) -> CliError {
+        CliError::Xml(err)
     }
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -349,7 +349,7 @@ impl Field {
         writer.write_all(self.tag.as_slice())?;
 
         if let Some(ref occurrence) = self.occurrence {
-            write!(writer, "{}", occurrence)?;
+            write!(writer, "/{}", occurrence)?;
         }
 
         writer.write_all(&[b' '])?;
@@ -391,7 +391,7 @@ impl fmt::Display for Field {
         write!(f, "{}", self.tag)?;
 
         if let Some(ref occurrence) = self.occurrence {
-            write!(f, "{}", occurrence)?;
+            write!(f, "/{}", occurrence)?;
         }
 
         if !self.is_empty() {

--- a/src/occurrence.rs
+++ b/src/occurrence.rs
@@ -72,7 +72,7 @@ impl Occurrence {
 impl fmt::Display for Occurrence {
     /// Format the occurrence in a human-readable format.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "/{}", self.0)?;
+        write!(f, "{}", self.0)?;
         Ok(())
     }
 }

--- a/tests/data/1004916019.xml
+++ b/tests/data/1004916019.xml
@@ -66,10 +66,10 @@
     <datafield tag="042A">
       <subfield code="a">31.7</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="e">DE-210</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="r">DE-384</subfield>
     </datafield>
     <datafield tag="047C">

--- a/tests/data/1004916019.xml
+++ b/tests/data/1004916019.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<collection xmlns="info:srw/schema/5/picaXML-v1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="info:srw/schema/5/picaXML-v1.0">
+  <record>
+    <datafield tag="001A">
+      <subfield code="0">8999:22-07-10</subfield>
+    </datafield>
+    <datafield tag="001B">
+      <subfield code="0">1250:10-09-14</subfield>
+      <subfield code="t">08:28:16.000</subfield>
+    </datafield>
+    <datafield tag="001D">
+      <subfield code="0">0384:27-07-10</subfield>
+    </datafield>
+    <datafield tag="001U">
+      <subfield code="0">utf8</subfield>
+    </datafield>
+    <datafield tag="001X">
+      <subfield code="0">0</subfield>
+    </datafield>
+    <datafield tag="002@">
+      <subfield code="0">Ts1</subfield>
+    </datafield>
+    <datafield tag="003@">
+      <subfield code="0">1004916019</subfield>
+    </datafield>
+    <datafield tag="003U">
+      <subfield code="a">http://d-nb.info/gnd/7710287-3</subfield>
+    </datafield>
+    <datafield tag="004B">
+      <subfield code="a">sip</subfield>
+    </datafield>
+    <datafield tag="007K">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">7710287-3</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">swd</subfield>
+      <subfield code="0">7710287-3</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="008A">
+      <subfield code="a">s</subfield>
+    </datafield>
+    <datafield tag="029R">
+      <subfield code="9">952570254</subfield>
+      <subfield code="7">Tb1</subfield>
+      <subfield code="V">kiz</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">5263070-5</subfield>
+      <subfield code="a">Chrysler Corporation</subfield>
+      <subfield code="4">hers</subfield>
+    </datafield>
+    <datafield tag="041A">
+      <subfield code="a">Plymouth</subfield>
+      <subfield code="g">Marke</subfield>
+    </datafield>
+    <datafield tag="041R">
+      <subfield code="9">041145135</subfield>
+      <subfield code="7">Ts1</subfield>
+      <subfield code="V">saz</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">4114513-6</subfield>
+      <subfield code="a">Markenname</subfield>
+      <subfield code="4">obin</subfield>
+    </datafield>
+    <datafield tag="042A">
+      <subfield code="a">31.7</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="e">DE-210</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="r">DE-384</subfield>
+    </datafield>
+    <datafield tag="047C">
+      <subfield code="S">swd</subfield>
+      <subfield code="i">s</subfield>
+      <subfield code="a">Plymouth &lt;Marke></subfield>
+      <subfield code="0">7710287-3</subfield>
+    </datafield>
+    <datafield tag="050D">
+      <subfield code="a">Kombiniere mit einer Produktgruppe, z.B. Personenkraftwagen</subfield>
+    </datafield>
+    <datafield tag="050E">
+      <subfield code="a">Wikipedia, Internet</subfield>
+      <subfield code="u">http://www.mobile.de/modellverzeichnis/plymouth/</subfield>
+    </datafield>
+    <datafield tag="050H">
+      <subfield code="a">Markenname</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/dump.xml
+++ b/tests/data/dump.xml
@@ -66,10 +66,10 @@
     <datafield tag="042A">
       <subfield code="a">31.7</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="e">DE-210</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="r">DE-384</subfield>
     </datafield>
     <datafield tag="047C">
@@ -284,10 +284,10 @@
     <datafield tag="042B">
       <subfield code="a">XA-GB</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="e">DE-386</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="r">DE-576</subfield>
     </datafield>
     <datafield tag="047C">
@@ -348,7 +348,7 @@
       <subfield code="a">London</subfield>
       <subfield code="4">orts</subfield>
     </datafield>
-    <datafield tag="070A">
+    <datafield tag="070A" occurrence="03">
       <subfield code="0">(DE-588)119232022</subfield>
     </datafield>
   </record>
@@ -471,10 +471,10 @@
     <datafield tag="042B">
       <subfield code="a">XD-US</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="e">DE-1</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="r">DE-1</subfield>
     </datafield>
     <datafield tag="047C">
@@ -593,10 +593,10 @@
     <datafield tag="042B">
       <subfield code="a">XD-US</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="e">DE-1</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="r">DE-1</subfield>
     </datafield>
     <datafield tag="047C">
@@ -629,7 +629,7 @@
       <subfield code="a">Minneapolis, Minn.</subfield>
       <subfield code="4">orta</subfield>
     </datafield>
-    <datafield tag="070A">
+    <datafield tag="070A" occurrence="03">
       <subfield code="S">IDS</subfield>
       <subfield code="0">320104243</subfield>
     </datafield>
@@ -754,10 +754,10 @@
     <datafield tag="042B">
       <subfield code="a">XP</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="e">DE-1</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="r">DE-1</subfield>
     </datafield>
     <datafield tag="047C">
@@ -797,7 +797,7 @@
       <subfield code="a">Paris</subfield>
       <subfield code="4">orta</subfield>
     </datafield>
-    <datafield tag="070A">
+    <datafield tag="070A" occurrence="03">
       <subfield code="S">IDS</subfield>
       <subfield code="0">000000307</subfield>
     </datafield>
@@ -898,10 +898,10 @@
     <datafield tag="042B">
       <subfield code="a">XD-US</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="e">DE-1</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="r">DE-1</subfield>
     </datafield>
     <datafield tag="047C">
@@ -937,7 +937,7 @@
       <subfield code="a">USA</subfield>
       <subfield code="4">geow</subfield>
     </datafield>
-    <datafield tag="070A">
+    <datafield tag="070A" occurrence="03">
       <subfield code="0">(DE-588)922-2</subfield>
     </datafield>
   </record>
@@ -1028,10 +1028,10 @@
     <datafield tag="042B">
       <subfield code="a">XA-DE</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="e">DE-386</subfield>
     </datafield>
-    <datafield tag="047A">
+    <datafield tag="047A" occurrence="03">
       <subfield code="r">DE-576</subfield>
     </datafield>
     <datafield tag="047C">

--- a/tests/data/dump.xml
+++ b/tests/data/dump.xml
@@ -1,0 +1,1060 @@
+<?xml version="1.0" encoding="utf-8"?>
+<collection xmlns="info:srw/schema/5/picaXML-v1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="info:srw/schema/5/picaXML-v1.0">
+  <record>
+    <datafield tag="001A">
+      <subfield code="0">8999:22-07-10</subfield>
+    </datafield>
+    <datafield tag="001B">
+      <subfield code="0">1250:10-09-14</subfield>
+      <subfield code="t">08:28:16.000</subfield>
+    </datafield>
+    <datafield tag="001D">
+      <subfield code="0">0384:27-07-10</subfield>
+    </datafield>
+    <datafield tag="001U">
+      <subfield code="0">utf8</subfield>
+    </datafield>
+    <datafield tag="001X">
+      <subfield code="0">0</subfield>
+    </datafield>
+    <datafield tag="002@">
+      <subfield code="0">Ts1</subfield>
+    </datafield>
+    <datafield tag="003@">
+      <subfield code="0">1004916019</subfield>
+    </datafield>
+    <datafield tag="003U">
+      <subfield code="a">http://d-nb.info/gnd/7710287-3</subfield>
+    </datafield>
+    <datafield tag="004B">
+      <subfield code="a">sip</subfield>
+    </datafield>
+    <datafield tag="007K">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">7710287-3</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">swd</subfield>
+      <subfield code="0">7710287-3</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="008A">
+      <subfield code="a">s</subfield>
+    </datafield>
+    <datafield tag="029R">
+      <subfield code="9">952570254</subfield>
+      <subfield code="7">Tb1</subfield>
+      <subfield code="V">kiz</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">5263070-5</subfield>
+      <subfield code="a">Chrysler Corporation</subfield>
+      <subfield code="4">hers</subfield>
+    </datafield>
+    <datafield tag="041A">
+      <subfield code="a">Plymouth</subfield>
+      <subfield code="g">Marke</subfield>
+    </datafield>
+    <datafield tag="041R">
+      <subfield code="9">041145135</subfield>
+      <subfield code="7">Ts1</subfield>
+      <subfield code="V">saz</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">4114513-6</subfield>
+      <subfield code="a">Markenname</subfield>
+      <subfield code="4">obin</subfield>
+    </datafield>
+    <datafield tag="042A">
+      <subfield code="a">31.7</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="e">DE-210</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="r">DE-384</subfield>
+    </datafield>
+    <datafield tag="047C">
+      <subfield code="S">swd</subfield>
+      <subfield code="i">s</subfield>
+      <subfield code="a">Plymouth &lt;Marke></subfield>
+      <subfield code="0">7710287-3</subfield>
+    </datafield>
+    <datafield tag="050D">
+      <subfield code="a">Kombiniere mit einer Produktgruppe, z.B. Personenkraftwagen</subfield>
+    </datafield>
+    <datafield tag="050E">
+      <subfield code="a">Wikipedia, Internet</subfield>
+      <subfield code="u">http://www.mobile.de/modellverzeichnis/plymouth/</subfield>
+    </datafield>
+    <datafield tag="050H">
+      <subfield code="a">Markenname</subfield>
+    </datafield>
+  </record>
+  <record>
+    <datafield tag="001A">
+      <subfield code="0">0386:16-03-95</subfield>
+    </datafield>
+    <datafield tag="001B">
+      <subfield code="0">8999:20-07-20</subfield>
+      <subfield code="t">13:19:49.000</subfield>
+    </datafield>
+    <datafield tag="001D">
+      <subfield code="0">9999:06-04-08</subfield>
+    </datafield>
+    <datafield tag="001U">
+      <subfield code="0">utf8</subfield>
+    </datafield>
+    <datafield tag="001X">
+      <subfield code="0">0</subfield>
+    </datafield>
+    <datafield tag="002@">
+      <subfield code="0">Tp1</subfield>
+    </datafield>
+    <datafield tag="003@">
+      <subfield code="0">119232022</subfield>
+    </datafield>
+    <datafield tag="003U">
+      <subfield code="a">http://d-nb.info/gnd/119232022</subfield>
+      <subfield code="z">http://d-nb.info/gnd/172642531</subfield>
+    </datafield>
+    <datafield tag="004B">
+      <subfield code="a">pik</subfield>
+    </datafield>
+    <datafield tag="007K">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">119232022</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">172642531</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">pnd</subfield>
+      <subfield code="0">172642531</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">pnd</subfield>
+      <subfield code="0">119232022</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">swd</subfield>
+      <subfield code="0">4370325-2</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="008A">
+      <subfield code="a">s</subfield>
+      <subfield code="a">z</subfield>
+      <subfield code="a">f</subfield>
+    </datafield>
+    <datafield tag="008B">
+      <subfield code="a">w</subfield>
+      <subfield code="a">k</subfield>
+      <subfield code="a">v</subfield>
+    </datafield>
+    <datafield tag="010E">
+      <subfield code="e">rda</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Ada K.</subfield>
+      <subfield code="c">of</subfield>
+      <subfield code="a">Lovelace</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Augusta Ada</subfield>
+      <subfield code="c">of</subfield>
+      <subfield code="a">Lovelace</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Ada Augusta</subfield>
+      <subfield code="c">of</subfield>
+      <subfield code="a">Lovelace</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Ada</subfield>
+      <subfield code="a">Byron</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Augusta Ada</subfield>
+      <subfield code="a">Byron King</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Augusta Ada</subfield>
+      <subfield code="a">King</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Ada</subfield>
+      <subfield code="a">King</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Ada Augusta</subfield>
+      <subfield code="a">Byron</subfield>
+      <subfield code="4">nafr</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Augusta Ada</subfield>
+      <subfield code="a">Byron</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Ada</subfield>
+      <subfield code="a">Byron Lovelace</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Ada</subfield>
+      <subfield code="a">Lovelace</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Ada King, Countess of</subfield>
+      <subfield code="a">Lovelace</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Augusta Ada King</subfield>
+      <subfield code="a">Lovelace</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Augusta Ada</subfield>
+      <subfield code="a">Lovelace</subfield>
+    </datafield>
+    <datafield tag="028A">
+      <subfield code="d">Ada King</subfield>
+      <subfield code="c">of</subfield>
+      <subfield code="a">Lovelace</subfield>
+    </datafield>
+    <datafield tag="028R">
+      <subfield code="9">118518208</subfield>
+      <subfield code="7">Tp1</subfield>
+      <subfield code="V">piz</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">118518208</subfield>
+      <subfield code="E">1788</subfield>
+      <subfield code="G">1824</subfield>
+      <subfield code="d">George Gordon Byron</subfield>
+      <subfield code="a">Byron</subfield>
+      <subfield code="l">Baron</subfield>
+      <subfield code="4">bezf</subfield>
+      <subfield code="v">Vater</subfield>
+    </datafield>
+    <datafield tag="028R">
+      <subfield code="9">118638130</subfield>
+      <subfield code="7">Tp1</subfield>
+      <subfield code="V">piz</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">118638130</subfield>
+      <subfield code="E">1792</subfield>
+      <subfield code="G">1860</subfield>
+      <subfield code="d">Anne Isabella Milbanke Byron</subfield>
+      <subfield code="a">Byron</subfield>
+      <subfield code="4">bezf</subfield>
+      <subfield code="v">Mutter</subfield>
+    </datafield>
+    <datafield tag="028R">
+      <subfield code="9">119389991</subfield>
+      <subfield code="7">Tp1</subfield>
+      <subfield code="V">piz</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">119389991</subfield>
+      <subfield code="E">1837</subfield>
+      <subfield code="G">1917</subfield>
+      <subfield code="d">Anne Isabella</subfield>
+      <subfield code="a">Blunt</subfield>
+      <subfield code="4">bezf</subfield>
+      <subfield code="v">Tochter</subfield>
+    </datafield>
+    <datafield tag="028R">
+      <subfield code="d">william</subfield>
+      <subfield code="a">king</subfield>
+      <subfield code="4">bezf</subfield>
+    </datafield>
+    <datafield tag="032T">
+      <subfield code="a">f</subfield>
+    </datafield>
+    <datafield tag="041R">
+      <subfield code="9">042527880</subfield>
+      <subfield code="7">Ts1</subfield>
+      <subfield code="V">saz</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">4252788-0</subfield>
+      <subfield code="a">Mathematikerin</subfield>
+      <subfield code="4">berc</subfield>
+    </datafield>
+    <datafield tag="042A">
+      <subfield code="a">28p</subfield>
+      <subfield code="a">9.5p</subfield>
+    </datafield>
+    <datafield tag="042B">
+      <subfield code="a">XA-GB</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="e">DE-386</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="r">DE-576</subfield>
+    </datafield>
+    <datafield tag="047C">
+      <subfield code="S">pnd</subfield>
+      <subfield code="i">a</subfield>
+      <subfield code="a">Lovelace, Ada King /of</subfield>
+      <subfield code="0">119232022</subfield>
+    </datafield>
+    <datafield tag="047C">
+      <subfield code="S">pnd</subfield>
+      <subfield code="i">a</subfield>
+      <subfield code="a">Lovelace, Ada K. /of</subfield>
+      <subfield code="0">172642531</subfield>
+    </datafield>
+    <datafield tag="050C">
+      <subfield code="a">Der Ehemann Baron William King (1805-1893) wurde 1838 zum 1. Earl of Lovelace erhoben.</subfield>
+    </datafield>
+    <datafield tag="050E">
+      <subfield code="a">LoC-Na gegen Modern Engl. biogr.</subfield>
+    </datafield>
+    <datafield tag="050E">
+      <subfield code="a">https://de.wikipedia.org/wiki/Ada_Lovelace</subfield>
+    </datafield>
+    <datafield tag="050E">
+      <subfield code="a">LCAuth, (OGND)</subfield>
+    </datafield>
+    <datafield tag="050G">
+      <subfield code="b">Brit. Mathematikerin; Countess of Lovelace</subfield>
+    </datafield>
+    <datafield tag="050G">
+      <subfield code="b">Informatikerin, Mathematikerin, Grossbritannien</subfield>
+    </datafield>
+    <datafield tag="060R">
+      <subfield code="a">10.12.1815</subfield>
+      <subfield code="b">27.12.1852</subfield>
+      <subfield code="4">datx</subfield>
+    </datafield>
+    <datafield tag="060R">
+      <subfield code="a">1815</subfield>
+      <subfield code="b">1852</subfield>
+      <subfield code="4">datl</subfield>
+    </datafield>
+    <datafield tag="065R">
+      <subfield code="9">040743357</subfield>
+      <subfield code="7">Tgz</subfield>
+      <subfield code="V">gik</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">4074335-4</subfield>
+      <subfield code="a">London</subfield>
+      <subfield code="4">ortg</subfield>
+    </datafield>
+    <datafield tag="065R">
+      <subfield code="9">040743357</subfield>
+      <subfield code="7">Tgz</subfield>
+      <subfield code="V">gik</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">4074335-4</subfield>
+      <subfield code="a">London</subfield>
+      <subfield code="4">orts</subfield>
+    </datafield>
+    <datafield tag="070A">
+      <subfield code="0">(DE-588)119232022</subfield>
+    </datafield>
+  </record>
+  <record>
+    <datafield tag="001@">
+      <subfield code="0">-</subfield>
+    </datafield>
+    <datafield tag="001A">
+      <subfield code="0">9002:18-04-89</subfield>
+    </datafield>
+    <datafield tag="001B">
+      <subfield code="0">9999:27-09-17</subfield>
+      <subfield code="t">00:43:48.000</subfield>
+    </datafield>
+    <datafield tag="001D">
+      <subfield code="0">9999:23-04-10</subfield>
+    </datafield>
+    <datafield tag="001U">
+      <subfield code="0">utf8</subfield>
+    </datafield>
+    <datafield tag="001X">
+      <subfield code="0">0</subfield>
+    </datafield>
+    <datafield tag="002@">
+      <subfield code="0">Tb1</subfield>
+    </datafield>
+    <datafield tag="003@">
+      <subfield code="0">000008672</subfield>
+    </datafield>
+    <datafield tag="003U">
+      <subfield code="a">http://d-nb.info/gnd/867-9</subfield>
+      <subfield code="z">http://d-nb.info/gnd/7538748-7</subfield>
+    </datafield>
+    <datafield tag="004B">
+      <subfield code="a">kiz</subfield>
+    </datafield>
+    <datafield tag="007K">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">867-9</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">7538748-7</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">1085295990</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">swd</subfield>
+      <subfield code="0">7538748-7</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gkd</subfield>
+      <subfield code="0">867-9</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="008A">
+      <subfield code="a">f</subfield>
+      <subfield code="a">s</subfield>
+    </datafield>
+    <datafield tag="008B">
+      <subfield code="a">z</subfield>
+      <subfield code="a">v</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">Vacuum Society</subfield>
+      <subfield code="g">USA</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">AVS</subfield>
+      <subfield code="4">abku</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">Committee on Vacuum Techniques</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">CVT</subfield>
+      <subfield code="4">abku</subfield>
+    </datafield>
+    <datafield tag="029A">
+      <subfield code="a">American Vacuum Society</subfield>
+    </datafield>
+    <datafield tag="029R">
+      <subfield code="9">984002073</subfield>
+      <subfield code="7">Tb1</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">10168051-X</subfield>
+      <subfield code="a">AVS, the Science and Technology Society</subfield>
+      <subfield code="4">nach</subfield>
+    </datafield>
+    <datafield tag="041R">
+      <subfield code="9">040622665</subfield>
+      <subfield code="7">Ts1</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">4062266-6</subfield>
+      <subfield code="a">Vakuum</subfield>
+      <subfield code="4">them</subfield>
+    </datafield>
+    <datafield tag="041R">
+      <subfield code="9">04066581X</subfield>
+      <subfield code="7">Ts1</subfield>
+      <subfield code="V">saz</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">4066581-1</subfield>
+      <subfield code="a">Wissenschaftliche Gesellschaft</subfield>
+      <subfield code="4">obin</subfield>
+    </datafield>
+    <datafield tag="042A">
+      <subfield code="a">6.5</subfield>
+      <subfield code="a">9.3c</subfield>
+      <subfield code="a">21.5</subfield>
+      <subfield code="a">31.1b</subfield>
+      <subfield code="a">31.9a</subfield>
+    </datafield>
+    <datafield tag="042B">
+      <subfield code="a">XD-US</subfield>
+    </datafield>
+    <datafield tag="042B">
+      <subfield code="a">XD-US</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="e">DE-1</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="r">DE-1</subfield>
+    </datafield>
+    <datafield tag="047C">
+      <subfield code="S">gkd</subfield>
+      <subfield code="i">a</subfield>
+      <subfield code="a">American Vacuum Society</subfield>
+      <subfield code="0">867-9</subfield>
+    </datafield>
+    <datafield tag="047C">
+      <subfield code="S">swd</subfield>
+      <subfield code="i">k</subfield>
+      <subfield code="a">American Vacuum Society</subfield>
+      <subfield code="0">7538748-7</subfield>
+    </datafield>
+    <datafield tag="050C">
+      <subfield code="a">MMi</subfield>
+    </datafield>
+    <datafield tag="050E">
+      <subfield code="a">GKD</subfield>
+    </datafield>
+    <datafield tag="050H">
+      <subfield code="a">1953 gegr. wiss. Ges., die sich mit Problemen des Vakuums und vor allem seiner Anwendung in der Technik beschäftigt</subfield>
+    </datafield>
+    <datafield tag="065R">
+      <subfield code="9">040787044</subfield>
+      <subfield code="7">Tgz</subfield>
+      <subfield code="V">gik</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">4078704-7</subfield>
+      <subfield code="a">USA</subfield>
+      <subfield code="4">geow</subfield>
+    </datafield>
+  </record>
+  <record>
+    <datafield tag="001@">
+      <subfield code="0">-</subfield>
+    </datafield>
+    <datafield tag="001A">
+      <subfield code="0">9002:18-04-89</subfield>
+    </datafield>
+    <datafield tag="001B">
+      <subfield code="0">1240:19-04-17</subfield>
+      <subfield code="t">14:37:25.000</subfield>
+    </datafield>
+    <datafield tag="001D">
+      <subfield code="0">9999:23-04-10</subfield>
+    </datafield>
+    <datafield tag="001U">
+      <subfield code="0">utf8</subfield>
+    </datafield>
+    <datafield tag="001X">
+      <subfield code="0">0</subfield>
+    </datafield>
+    <datafield tag="002@">
+      <subfield code="0">Tb1</subfield>
+    </datafield>
+    <datafield tag="003@">
+      <subfield code="0">000016586</subfield>
+    </datafield>
+    <datafield tag="003U">
+      <subfield code="a">http://d-nb.info/gnd/1658-5</subfield>
+      <subfield code="z">http://d-nb.info/gnd/4318278-1</subfield>
+    </datafield>
+    <datafield tag="004B">
+      <subfield code="a">kiz</subfield>
+    </datafield>
+    <datafield tag="007K">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">1658-5</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">4318278-1</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">swd</subfield>
+      <subfield code="0">4318278-1</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gkd</subfield>
+      <subfield code="0">16291087-3</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gkd</subfield>
+      <subfield code="0">1658-5</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="008A">
+      <subfield code="a">f</subfield>
+      <subfield code="a">s</subfield>
+    </datafield>
+    <datafield tag="008B">
+      <subfield code="a">z</subfield>
+      <subfield code="a">v</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">Univ. of Minnesota, Minneapolis</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">Universidad de Minnesota</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">U of M</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">UM</subfield>
+      <subfield code="4">abku</subfield>
+    </datafield>
+    <datafield tag="029A">
+      <subfield code="a">University of Minnesota</subfield>
+    </datafield>
+    <datafield tag="042A">
+      <subfield code="a">6.6</subfield>
+    </datafield>
+    <datafield tag="042B">
+      <subfield code="a">XD-US</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="e">DE-1</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="r">DE-1</subfield>
+    </datafield>
+    <datafield tag="047C">
+      <subfield code="S">gkd</subfield>
+      <subfield code="i">a</subfield>
+      <subfield code="a">University of Minnesota &lt;Minneapolis, Minn.></subfield>
+      <subfield code="0">1658-5</subfield>
+    </datafield>
+    <datafield tag="047C">
+      <subfield code="S">swd</subfield>
+      <subfield code="i">c</subfield>
+      <subfield code="a">Minneapolis &lt;Minn.> / University of Minnesota</subfield>
+      <subfield code="0">4318278-1</subfield>
+    </datafield>
+    <datafield tag="050E">
+      <subfield code="a">Homepage</subfield>
+      <subfield code="b">Stand: 19.04.2017</subfield>
+      <subfield code="u">http://www.umn.edu</subfield>
+    </datafield>
+    <datafield tag="060R">
+      <subfield code="a">1851</subfield>
+      <subfield code="4">datb</subfield>
+    </datafield>
+    <datafield tag="065R">
+      <subfield code="9">040394972</subfield>
+      <subfield code="7">Tg1</subfield>
+      <subfield code="V">gik</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">4039497-9</subfield>
+      <subfield code="a">Minneapolis, Minn.</subfield>
+      <subfield code="4">orta</subfield>
+    </datafield>
+    <datafield tag="070A">
+      <subfield code="S">IDS</subfield>
+      <subfield code="0">320104243</subfield>
+    </datafield>
+  </record>
+  <record>
+    <datafield tag="001@">
+      <subfield code="0">-</subfield>
+    </datafield>
+    <datafield tag="001A">
+      <subfield code="0">9002:18-04-89</subfield>
+    </datafield>
+    <datafield tag="001B">
+      <subfield code="0">1601:26-11-19</subfield>
+      <subfield code="t">10:50:14.000</subfield>
+    </datafield>
+    <datafield tag="001D">
+      <subfield code="0">9999:23-04-10</subfield>
+    </datafield>
+    <datafield tag="001U">
+      <subfield code="0">utf8</subfield>
+    </datafield>
+    <datafield tag="001X">
+      <subfield code="0">0</subfield>
+    </datafield>
+    <datafield tag="002@">
+      <subfield code="0">Tb1</subfield>
+    </datafield>
+    <datafield tag="003@">
+      <subfield code="0">000016756</subfield>
+    </datafield>
+    <datafield tag="003U">
+      <subfield code="a">http://d-nb.info/gnd/1675-5</subfield>
+      <subfield code="z">http://d-nb.info/gnd/1088210104</subfield>
+      <subfield code="z">http://d-nb.info/gnd/7542287-6</subfield>
+      <subfield code="z">http://d-nb.info/gnd/1086256751</subfield>
+    </datafield>
+    <datafield tag="004B">
+      <subfield code="a">kiz</subfield>
+    </datafield>
+    <datafield tag="007K">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">1675-5</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">1086256751</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">7542287-6</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">swd</subfield>
+      <subfield code="0">7542287-6</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">1088210104</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gkd</subfield>
+      <subfield code="0">1675-5</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="008A">
+      <subfield code="a">f</subfield>
+      <subfield code="a">s</subfield>
+    </datafield>
+    <datafield tag="008B">
+      <subfield code="a">v</subfield>
+      <subfield code="a">z</subfield>
+    </datafield>
+    <datafield tag="010E">
+      <subfield code="b">ger</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">Institut International de Philosophie</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">Internationales Institut für Philosophie</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">Instituto Internacional de Filosofia</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">Institute of Philosophy</subfield>
+      <subfield code="g">International Institute of Philosophie</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">Institut für Philosophie</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">IIP</subfield>
+      <subfield code="4">abku</subfield>
+    </datafield>
+    <datafield tag="029A">
+      <subfield code="a">International Institute of Philosophy</subfield>
+    </datafield>
+    <datafield tag="029R">
+      <subfield code="9">000261246</subfield>
+      <subfield code="7">Tb1</subfield>
+      <subfield code="V">kiz</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">26124-5</subfield>
+      <subfield code="a">Institut International de Collaboration Philosophique</subfield>
+      <subfield code="g">Paris</subfield>
+      <subfield code="4">vorg</subfield>
+    </datafield>
+    <datafield tag="041R">
+      <subfield code="9">041900944</subfield>
+      <subfield code="7">Ts1</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">4190094-7</subfield>
+      <subfield code="a">Wissenschaftliche Einrichtung</subfield>
+      <subfield code="4">obin</subfield>
+    </datafield>
+    <datafield tag="042A">
+      <subfield code="a">6.5</subfield>
+      <subfield code="a">4.1</subfield>
+    </datafield>
+    <datafield tag="042B">
+      <subfield code="a">XP</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="e">DE-1</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="r">DE-1</subfield>
+    </datafield>
+    <datafield tag="047C">
+      <subfield code="S">gkd</subfield>
+      <subfield code="i">a</subfield>
+      <subfield code="a">International Institute of Philosophy</subfield>
+      <subfield code="0">1675-5</subfield>
+    </datafield>
+    <datafield tag="047C">
+      <subfield code="S">swd</subfield>
+      <subfield code="i">c</subfield>
+      <subfield code="a">Paris / Internationales Institut für Philosophie</subfield>
+      <subfield code="0">7542287-6</subfield>
+    </datafield>
+    <datafield tag="050E">
+      <subfield code="a">Yearb. 1995</subfield>
+    </datafield>
+    <datafield tag="060R">
+      <subfield code="a">1937</subfield>
+      <subfield code="4">datb</subfield>
+    </datafield>
+    <datafield tag="065R">
+      <subfield code="9">040181456</subfield>
+      <subfield code="7">Tgz</subfield>
+      <subfield code="V">gik</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">4018145-5</subfield>
+      <subfield code="a">Frankreich</subfield>
+      <subfield code="4">geow</subfield>
+    </datafield>
+    <datafield tag="065R">
+      <subfield code="9">040446603</subfield>
+      <subfield code="7">Tgz</subfield>
+      <subfield code="V">gik</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">4044660-8</subfield>
+      <subfield code="a">Paris</subfield>
+      <subfield code="4">orta</subfield>
+    </datafield>
+    <datafield tag="070A">
+      <subfield code="S">IDS</subfield>
+      <subfield code="0">000000307</subfield>
+    </datafield>
+  </record>
+  <record>
+    <datafield tag="001@">
+      <subfield code="0">-</subfield>
+    </datafield>
+    <datafield tag="001A">
+      <subfield code="0">9002:18-04-89</subfield>
+    </datafield>
+    <datafield tag="001B">
+      <subfield code="0">9999:05-06-20</subfield>
+      <subfield code="t">05:40:04.000</subfield>
+    </datafield>
+    <datafield tag="001D">
+      <subfield code="0">9999:23-04-10</subfield>
+    </datafield>
+    <datafield tag="001U">
+      <subfield code="0">utf8</subfield>
+    </datafield>
+    <datafield tag="001X">
+      <subfield code="0">0</subfield>
+    </datafield>
+    <datafield tag="002@">
+      <subfield code="0">Tb1</subfield>
+    </datafield>
+    <datafield tag="003@">
+      <subfield code="0">000009229</subfield>
+    </datafield>
+    <datafield tag="003U">
+      <subfield code="a">http://d-nb.info/gnd/922-2</subfield>
+      <subfield code="z">http://d-nb.info/gnd/4499175-7</subfield>
+      <subfield code="z">http://d-nb.info/gnd/1090453043</subfield>
+    </datafield>
+    <datafield tag="004B">
+      <subfield code="a">kiz</subfield>
+    </datafield>
+    <datafield tag="007K">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">922-2</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">1090453043</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">4499175-7</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">swd</subfield>
+      <subfield code="0">4499175-7</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gkd</subfield>
+      <subfield code="0">922-2</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="008A">
+      <subfield code="a">f</subfield>
+      <subfield code="a">s</subfield>
+    </datafield>
+    <datafield tag="008B">
+      <subfield code="a">z</subfield>
+      <subfield code="a">v</subfield>
+      <subfield code="a">w</subfield>
+      <subfield code="a">e</subfield>
+    </datafield>
+    <datafield tag="010E">
+      <subfield code="b">ger</subfield>
+      <subfield code="e">rda</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">Cancer Society</subfield>
+      <subfield code="g">USA</subfield>
+    </datafield>
+    <datafield tag="029@">
+      <subfield code="a">ACS</subfield>
+      <subfield code="4">abku</subfield>
+    </datafield>
+    <datafield tag="029A">
+      <subfield code="a">American Cancer Society</subfield>
+    </datafield>
+    <datafield tag="029R">
+      <subfield code="9">005078091</subfield>
+      <subfield code="7">Tb1</subfield>
+      <subfield code="V">kiz</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">507809-X</subfield>
+      <subfield code="a">American Society for the Control of Cancer</subfield>
+      <subfield code="4">vorg</subfield>
+    </datafield>
+    <datafield tag="042A">
+      <subfield code="a">27.4</subfield>
+    </datafield>
+    <datafield tag="042B">
+      <subfield code="a">XD-US</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="e">DE-1</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="r">DE-1</subfield>
+    </datafield>
+    <datafield tag="047C">
+      <subfield code="S">gkd</subfield>
+      <subfield code="i">a</subfield>
+      <subfield code="a">American Cancer Society</subfield>
+      <subfield code="0">922-2</subfield>
+    </datafield>
+    <datafield tag="047C">
+      <subfield code="S">swd</subfield>
+      <subfield code="i">k</subfield>
+      <subfield code="a">American Cancer Society</subfield>
+      <subfield code="0">4499175-7</subfield>
+    </datafield>
+    <datafield tag="050E">
+      <subfield code="a">GKD</subfield>
+    </datafield>
+    <datafield tag="050E">
+      <subfield code="a">Homepage</subfield>
+      <subfield code="b">Stand: 08.10.2018</subfield>
+      <subfield code="u">https://www.cancer.org</subfield>
+    </datafield>
+    <datafield tag="060R">
+      <subfield code="a">1945</subfield>
+      <subfield code="4">datb</subfield>
+    </datafield>
+    <datafield tag="065R">
+      <subfield code="9">040787044</subfield>
+      <subfield code="7">Tgz</subfield>
+      <subfield code="V">gik</subfield>
+      <subfield code="A">gnd</subfield>
+      <subfield code="0">4078704-7</subfield>
+      <subfield code="a">USA</subfield>
+      <subfield code="4">geow</subfield>
+    </datafield>
+    <datafield tag="070A">
+      <subfield code="0">(DE-588)922-2</subfield>
+    </datafield>
+  </record>
+  <record>
+    <datafield tag="001@">
+      <subfield code="0">-</subfield>
+    </datafield>
+    <datafield tag="001A">
+      <subfield code="0">0386:17-06-99</subfield>
+    </datafield>
+    <datafield tag="001B">
+      <subfield code="0">9999:17-10-16</subfield>
+      <subfield code="t">17:00:44.000</subfield>
+    </datafield>
+    <datafield tag="001D">
+      <subfield code="0">9999:06-04-08</subfield>
+    </datafield>
+    <datafield tag="001U">
+      <subfield code="0">utf8</subfield>
+    </datafield>
+    <datafield tag="001X">
+      <subfield code="0">0</subfield>
+    </datafield>
+    <datafield tag="002@">
+      <subfield code="0">Tp1</subfield>
+    </datafield>
+    <datafield tag="003@">
+      <subfield code="0">121169502</subfield>
+    </datafield>
+    <datafield tag="003U">
+      <subfield code="a">http://d-nb.info/gnd/121169502</subfield>
+      <subfield code="z">http://d-nb.info/gnd/183361946</subfield>
+    </datafield>
+    <datafield tag="004B">
+      <subfield code="a">piz</subfield>
+    </datafield>
+    <datafield tag="007K">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">121169502</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">gnd</subfield>
+      <subfield code="0">183361946</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">pnd</subfield>
+      <subfield code="0">183361946</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">pnd</subfield>
+      <subfield code="0">121169502</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="007N">
+      <subfield code="a">swd</subfield>
+      <subfield code="0">4549141-0</subfield>
+      <subfield code="v">zg</subfield>
+    </datafield>
+    <datafield tag="008A">
+      <subfield code="a">s</subfield>
+      <subfield code="a">f</subfield>
+    </datafield>
+    <datafield tag="008B">
+      <subfield code="a">v</subfield>
+      <subfield code="a">w</subfield>
+    </datafield>
+    <datafield tag="028@">
+      <subfield code="d">Heike</subfield>
+      <subfield code="a">Klußmann</subfield>
+    </datafield>
+    <datafield tag="028A">
+      <subfield code="d">Heike</subfield>
+      <subfield code="a">Klussmann</subfield>
+    </datafield>
+    <datafield tag="041R">
+      <subfield code="a">Installationskünstlerin</subfield>
+      <subfield code="4">berc</subfield>
+    </datafield>
+    <datafield tag="041R">
+      <subfield code="a">Photographin</subfield>
+      <subfield code="4">beru</subfield>
+    </datafield>
+    <datafield tag="042A">
+      <subfield code="a">13.7p</subfield>
+      <subfield code="a">13.5p</subfield>
+    </datafield>
+    <datafield tag="042B">
+      <subfield code="a">XA-DE</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="e">DE-386</subfield>
+    </datafield>
+    <datafield tag="047A">
+      <subfield code="r">DE-576</subfield>
+    </datafield>
+    <datafield tag="047C">
+      <subfield code="S">pnd</subfield>
+      <subfield code="i">a</subfield>
+      <subfield code="a">Klussmann, Heike</subfield>
+      <subfield code="0">121169502</subfield>
+    </datafield>
+    <datafield tag="047C">
+      <subfield code="S">pnd</subfield>
+      <subfield code="i">a</subfield>
+      <subfield code="a">Klussmann, Heike</subfield>
+      <subfield code="0">183361946</subfield>
+    </datafield>
+    <datafield tag="050C">
+      <subfield code="a">NDSBIO</subfield>
+    </datafield>
+    <datafield tag="050E">
+      <subfield code="a">Internet</subfield>
+    </datafield>
+    <datafield tag="060R">
+      <subfield code="a">1968</subfield>
+      <subfield code="4">datl</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/invalid.xml
+++ b/tests/data/invalid.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<collection xmlns="info:srw/schema/5/picaXML-v1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="info:srw/schema/5/picaXML-v1.0" />

--- a/tests/pica/mod.rs
+++ b/tests/pica/mod.rs
@@ -14,6 +14,7 @@ mod sample;
 mod select;
 mod slice;
 mod split;
+mod xml;
 
 #[test]
 fn pica_io_error() -> TestResult {

--- a/tests/pica/xml.rs
+++ b/tests/pica/xml.rs
@@ -11,6 +11,12 @@ fn pica_xml_single_record() -> TestResult {
     let assert = cmd.arg("xml").arg("tests/data/1004916019.dat").assert();
 
     let expected = read_to_string("tests/data/1004916019.xml").unwrap();
+    let expected = if cfg!(windows) {
+        expected.replace("\r", "")
+    } else {
+        expected
+    };
+
     assert.success().stdout(expected.trim_end().to_string());
 
     Ok(())
@@ -26,6 +32,12 @@ fn pica_xml_multiple_records() -> TestResult {
         .assert();
 
     let expected = read_to_string("tests/data/dump.xml").unwrap();
+    let expected = if cfg!(windows) {
+        expected.replace("\r", "")
+    } else {
+        expected
+    };
+
     assert.success().stdout(expected.trim_end().to_string());
 
     Ok(())
@@ -46,6 +58,12 @@ fn pica_xml_write_output() -> TestResult {
     assert.success();
 
     let expected = read_to_string("tests/data/1004916019.xml").unwrap();
+    let expected = if cfg!(windows) {
+        expected.replace("\r", "")
+    } else {
+        expected
+    };
+
     let actual = read_to_string(filename_str).unwrap();
     assert_eq!(expected.trim_end().to_string(), actual);
 
@@ -60,7 +78,15 @@ fn pica_xml_skip_invalid() -> TestResult {
         .arg("--skip-invalid")
         .arg("tests/data/invalid.dat")
         .assert();
-    assert.success().stdout(predicate::eq("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<collection xmlns=\"info:srw/schema/5/picaXML-v1.0\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"info:srw/schema/5/picaXML-v1.0\" />"));
+
+    let expected = read_to_string("tests/data/invalid.xml").unwrap();
+    let expected = if cfg!(windows) {
+        expected.replace("\r", "")
+    } else {
+        expected
+    };
+
+    assert.success().stdout(expected.trim_end().to_string());
 
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd.arg("xml").arg("tests/data/dump.dat.gz").assert();
@@ -82,6 +108,12 @@ skip-invalid = true
         .assert();
 
     let expected = read_to_string("tests/data/1004916019.xml").unwrap();
+    let expected = if cfg!(windows) {
+        expected.replace("\r", "")
+    } else {
+        expected
+    };
+
     assert.success().stdout(expected.trim_end().to_string());
 
     let mut cmd = Command::cargo_bin("pica")?;
@@ -97,6 +129,12 @@ skip-invalid = true
         .assert();
 
     let expected = read_to_string("tests/data/1004916019.xml").unwrap();
+    let expected = if cfg!(windows) {
+        expected.replace("\r", "")
+    } else {
+        expected
+    };
+
     assert.success().stdout(expected.trim_end().to_string());
 
     let mut cmd = Command::cargo_bin("pica")?;
@@ -115,6 +153,12 @@ skip-invalid = true
         .assert();
 
     let expected = read_to_string("tests/data/1004916019.xml").unwrap();
+    let expected = if cfg!(windows) {
+        expected.replace("\r", "")
+    } else {
+        expected
+    };
+
     assert.success().stdout(expected.trim_end().to_string());
 
     let mut cmd = Command::cargo_bin("pica")?;
@@ -134,6 +178,12 @@ skip-invalid = false
         .assert();
 
     let expected = read_to_string("tests/data/1004916019.xml").unwrap();
+    let expected = if cfg!(windows) {
+        expected.replace("\r", "")
+    } else {
+        expected
+    };
+
     assert.success().stdout(expected.trim_end().to_string());
 
     Ok(())

--- a/tests/pica/xml.rs
+++ b/tests/pica/xml.rs
@@ -1,0 +1,140 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs::read_to_string;
+use tempfile::Builder;
+
+use crate::common::{CommandExt, TestContext, TestResult};
+
+#[test]
+fn pica_xml_single_record() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd.arg("xml").arg("tests/data/1004916019.dat").assert();
+
+    let expected = read_to_string("tests/data/1004916019.xml").unwrap();
+    assert.success().stdout(expected.trim_end().to_string());
+
+    Ok(())
+}
+
+#[test]
+fn pica_xml_multiple_records() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("xml")
+        .arg("--skip-invalid")
+        .arg("tests/data/dump.dat.gz")
+        .assert();
+
+    let expected = read_to_string("tests/data/dump.xml").unwrap();
+    assert.success().stdout(expected.trim_end().to_string());
+
+    Ok(())
+}
+
+#[test]
+fn pica_xml_write_output() -> TestResult {
+    let filename = Builder::new().suffix(".xml").tempfile()?;
+    let filename_str = filename.path();
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("xml")
+        .arg("--output")
+        .arg(filename_str)
+        .arg("tests/data/1004916019.dat")
+        .assert();
+    assert.success();
+
+    let expected = read_to_string("tests/data/1004916019.xml").unwrap();
+    let actual = read_to_string(filename_str).unwrap();
+    assert_eq!(expected.trim_end().to_string(), actual);
+
+    Ok(())
+}
+
+#[test]
+fn pica_xml_skip_invalid() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("xml")
+        .arg("--skip-invalid")
+        .arg("tests/data/invalid.dat")
+        .assert();
+    assert.success().stdout(predicate::eq("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<collection xmlns=\"info:srw/schema/5/picaXML-v1.0\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"info:srw/schema/5/picaXML-v1.0\" />"));
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd.arg("xml").arg("tests/data/dump.dat.gz").assert();
+    assert
+        .failure()
+        .code(1)
+        .stderr(predicate::eq("Pica Error: Invalid record on line 2.\n"));
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .with_config(
+            &TestContext::new(),
+            r#"[xml]
+skip-invalid = true
+"#,
+        )
+        .arg("xml")
+        .arg("tests/data/1004916019.dat")
+        .assert();
+
+    let expected = read_to_string("tests/data/1004916019.xml").unwrap();
+    assert.success().stdout(expected.trim_end().to_string());
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .with_config(
+            &TestContext::new(),
+            r#"[global]
+skip-invalid = true
+"#,
+        )
+        .arg("xml")
+        .arg("tests/data/1004916019.dat")
+        .assert();
+
+    let expected = read_to_string("tests/data/1004916019.xml").unwrap();
+    assert.success().stdout(expected.trim_end().to_string());
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .with_config(
+            &TestContext::new(),
+            r#"[global]
+skip-invalid = false
+
+[xml]
+skip-invalid = true
+"#,
+        )
+        .arg("xml")
+        .arg("tests/data/1004916019.dat")
+        .assert();
+
+    let expected = read_to_string("tests/data/1004916019.xml").unwrap();
+    assert.success().stdout(expected.trim_end().to_string());
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .with_config(
+            &TestContext::new(),
+            r#"[global]
+skip-invalid = false
+
+[xml]
+skip-invalid = false
+"#,
+        )
+        .arg("xml")
+        .arg("--skip-invalid")
+        .arg("tests/data/1004916019.dat")
+        .assert();
+
+    let expected = read_to_string("tests/data/1004916019.xml").unwrap();
+    assert.success().stdout(expected.trim_end().to_string());
+
+    Ok(())
+}


### PR DESCRIPTION
This change adds a new command to serialize PICA+ records to [PICA XML](https://verbundwiki.gbv.de/display/VZG/PICA+XML+Version+1.0).

The command 
```shell
$ pica xml --skip-invalid tests/data/1004916019.dat
```

produces the following XMl document:

```xml
<?xml version="1.0" encoding="utf-8"?>
<collection xmlns="info:srw/schema/5/picaXML-v1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="info:srw/schema/5/picaXML-v1.0">
  <record>
    <datafield tag="001A">
      <subfield code="0">8999:22-07-10</subfield>
    </datafield>
    <datafield tag="001B">
      <subfield code="0">1250:10-09-14</subfield>
      <subfield code="t">08:28:16.000</subfield>
    </datafield>
    <datafield tag="001D">
      <subfield code="0">0384:27-07-10</subfield>
    </datafield>
    <datafield tag="001U">
      <subfield code="0">utf8</subfield>
    </datafield>
    <datafield tag="001X">
      <subfield code="0">0</subfield>
    </datafield>
    <datafield tag="002@">
      <subfield code="0">Ts1</subfield>
    </datafield>
    <datafield tag="003@">
      <subfield code="0">1004916019</subfield>
    </datafield>
    <datafield tag="003U">
      <subfield code="a">http://d-nb.info/gnd/7710287-3</subfield>
    </datafield>
    <datafield tag="004B">
      <subfield code="a">sip</subfield>
    </datafield>
    <datafield tag="007K">
      <subfield code="a">gnd</subfield>
      <subfield code="0">7710287-3</subfield>
    </datafield>
    <datafield tag="007N">
      <subfield code="a">swd</subfield>
      <subfield code="0">7710287-3</subfield>
      <subfield code="v">zg</subfield>
    </datafield>
    <datafield tag="008A">
      <subfield code="a">s</subfield>
    </datafield>
    <datafield tag="029R">
      <subfield code="9">952570254</subfield>
      <subfield code="7">Tb1</subfield>
      <subfield code="V">kiz</subfield>
      <subfield code="A">gnd</subfield>
      <subfield code="0">5263070-5</subfield>
      <subfield code="a">Chrysler Corporation</subfield>
      <subfield code="4">hers</subfield>
    </datafield>
    <datafield tag="041A">
      <subfield code="a">Plymouth</subfield>
      <subfield code="g">Marke</subfield>
    </datafield>
    <datafield tag="041R">
      <subfield code="9">041145135</subfield>
      <subfield code="7">Ts1</subfield>
      <subfield code="V">saz</subfield>
      <subfield code="A">gnd</subfield>
      <subfield code="0">4114513-6</subfield>
      <subfield code="a">Markenname</subfield>
      <subfield code="4">obin</subfield>
    </datafield>
    <datafield tag="042A">
      <subfield code="a">31.7</subfield>
    </datafield>
    <datafield tag="047A">
      <subfield code="e">DE-210</subfield>
    </datafield>
    <datafield tag="047A">
      <subfield code="r">DE-384</subfield>
    </datafield>
    <datafield tag="047C">
      <subfield code="S">swd</subfield>
      <subfield code="i">s</subfield>
      <subfield code="a">Plymouth &lt;Marke></subfield>
      <subfield code="0">7710287-3</subfield>
    </datafield>
    <datafield tag="050D">
      <subfield code="a">Kombiniere mit einer Produktgruppe, z.B. Personenkraftwagen</subfield>
    </datafield>
    <datafield tag="050E">
      <subfield code="a">Wikipedia, Internet</subfield>
      <subfield code="u">http://www.mobile.de/modellverzeichnis/plymouth/</subfield>
    </datafield>
    <datafield tag="050H">
      <subfield code="a">Markenname</subfield>
    </datafield>
  </record>
</collection>
```

Closes #192