### PR TITLE
Add check for unused dependencies in `Cargo.toml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,34 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
 
+  udeps:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v2
+      - uses: abbbi/github-actions-tune@v1
+      - uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-cargo-stable-${{ hashFiles('**/Cargo.toml') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            components: clippy
+            override: true
+      - uses: actions-rs/install@v0.1
+        with:
+          use-tool-cache: true
+          crate: cargo-udeps
+          version: latest
+      - run: |
+          cargo +nightly udeps
+
   audit:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
@@ -313,7 +341,7 @@ jobs:
   gh-pages:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
-    needs: [test, fuzz, rustfmt, coverage, clippy, audit, upgrades, book]
+    needs: [test, fuzz, rustfmt, coverage, clippy, audit, upgrades, book, udeps]
     steps:
       - uses: actions/checkout@v2
       - uses: abbbi/github-actions-tune@v1


### PR DESCRIPTION
This PR adds a new test which checks for unused dependencies in `Cargo.toml` using [cargo-udeps](https://github.com/est31/cargo-udeps).