### PR TITLE
Add `--translit` option to `xml` command

### DIFF
--- a/tests/data/004732650-nfc.xml
+++ b/tests/data/004732650-nfc.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<collection xmlns="info:srw/schema/5/picaXML-v1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="info:srw/schema/5/picaXML-v1.0">
+  <record>
+    <datafield tag="029A">
+      <subfield code="a">Goethe-Universität Frankfurt am Main</subfield>
+      <subfield code="b">Institut für Sozialforschung</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/004732650-nfd.xml
+++ b/tests/data/004732650-nfd.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<collection xmlns="info:srw/schema/5/picaXML-v1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="info:srw/schema/5/picaXML-v1.0">
+  <record>
+    <datafield tag="029A">
+      <subfield code="a">Goethe-Universität Frankfurt am Main</subfield>
+      <subfield code="b">Institut für Sozialforschung</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/pica/xml.rs
+++ b/tests/pica/xml.rs
@@ -79,6 +79,12 @@ fn pica_xml_translit() -> TestResult {
         .assert();
 
     let expected = read_to_string("tests/data/004732650-nfd.xml").unwrap();
+    let expected = if cfg!(windows) {
+        expected.replace('\r', "")
+    } else {
+        expected
+    };
+
     assert.success().stdout(expected.trim_end().to_string());
 
     let expected = vec![

--- a/tests/pica/xml.rs
+++ b/tests/pica/xml.rs
@@ -71,6 +71,40 @@ fn pica_xml_write_output() -> TestResult {
 }
 
 #[test]
+fn pica_xml_translit() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("xml")
+        .arg("tests/data/004732650-reduced.dat.gz")
+        .assert();
+
+    let expected = read_to_string("tests/data/004732650-nfd.xml").unwrap();
+    assert.success().stdout(expected.trim_end().to_string());
+
+    let expected = vec![
+        ("nfd", "tests/data/004732650-nfd.xml"),
+        ("nfkd", "tests/data/004732650-nfd.xml"),
+        ("nfc", "tests/data/004732650-nfc.xml"),
+        ("nfkc", "tests/data/004732650-nfc.xml"),
+    ];
+
+    for (translit, output) in expected {
+        let mut cmd = Command::cargo_bin("pica")?;
+        let assert = cmd
+            .arg("xml")
+            .arg("--translit")
+            .arg(translit)
+            .arg("tests/data/004732650-reduced.dat.gz")
+            .assert();
+
+        let expected = read_to_string(output).unwrap();
+        assert.success().stdout(expected.trim_end().to_string());
+    }
+
+    Ok(())
+}
+
+#[test]
 fn pica_xml_skip_invalid() -> TestResult {
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd

--- a/tests/pica/xml.rs
+++ b/tests/pica/xml.rs
@@ -98,6 +98,12 @@ fn pica_xml_translit() -> TestResult {
             .assert();
 
         let expected = read_to_string(output).unwrap();
+        let expected = if cfg!(windows) {
+            expected.replace('\r', "")
+        } else {
+            expected
+        };
+
         assert.success().stdout(expected.trim_end().to_string());
     }
 


### PR DESCRIPTION
## Example

- [Unicode Character “ä” (U+00E4)](https://www.compart.com/en/unicode/U+00E4), UTF8-Encoding: 0xC3 0xA4, Decomposed: [a (U+0061)](https://www.compart.com/en/unicode/U+0061) - [◌̈ (U+0308)](https://www.compart.com/en/unicode/U+0308)
- [Unicode Character “a” (U+0061)](https://www.compart.com/en/unicode/U+0061), UTF8-Encoding: 0x61
- [Unicode Character “◌̈” (U+0308)](https://www.compart.com/en/unicode/U+0308), UTF8-Encoding: 0xCC 0x88

### No transliteration (default, NFD → NFD)

```bash
$ pica filter --reduce "029A" "003@.0?" tests/data/004732650.dat.gz  | \
       pica xml | hexdump -C
00000000  3c 3f 78 6d 6c 20 76 65  72 73 69 6f 6e 3d 22 31  |<?xml version="1|
00000010  2e 30 22 20 65 6e 63 6f  64 69 6e 67 3d 22 75 74  |.0" encoding="ut|
00000020  66 2d 38 22 3f 3e 0a 3c  63 6f 6c 6c 65 63 74 69  |f-8"?>.<collecti|
00000030  6f 6e 20 78 6d 6c 6e 73  3d 22 69 6e 66 6f 3a 73  |on xmlns="info:s|
00000040  72 77 2f 73 63 68 65 6d  61 2f 35 2f 70 69 63 61  |rw/schema/5/pica|
00000050  58 4d 4c 2d 76 31 2e 30  22 20 78 6d 6c 6e 73 3a  |XML-v1.0" xmlns:|
00000060  78 73 3d 22 68 74 74 70  3a 2f 2f 77 77 77 2e 77  |xs="http://www.w|
00000070  33 2e 6f 72 67 2f 32 30  30 31 2f 58 4d 4c 53 63  |3.org/2001/XMLSc|
00000080  68 65 6d 61 22 20 74 61  72 67 65 74 4e 61 6d 65  |hema" targetName|
00000090  73 70 61 63 65 3d 22 69  6e 66 6f 3a 73 72 77 2f  |space="info:srw/|
000000a0  73 63 68 65 6d 61 2f 35  2f 70 69 63 61 58 4d 4c  |schema/5/picaXML|
000000b0  2d 76 31 2e 30 22 3e 0a  20 20 3c 72 65 63 6f 72  |-v1.0">.  <recor|
000000c0  64 3e 0a 20 20 20 20 3c  64 61 74 61 66 69 65 6c  |d>.    <datafiel|
000000d0  64 20 74 61 67 3d 22 30  32 39 41 22 3e 0a 20 20  |d tag="029A">.  |
000000e0  20 20 20 20 3c 73 75 62  66 69 65 6c 64 20 63 6f  |    <subfield co|
000000f0  64 65 3d 22 61 22 3e 47  6f 65 74 68 65 2d 55 6e  |de="a">Goethe-Un|
00000100  69 76 65 72 73 69 74 61  cc 88 74 20 46 72 61 6e  |iversita..t Fran|
00000110  6b 66 75 72 74 20 61 6d  20 4d 61 69 6e 3c 2f 73  |kfurt am Main</s|
00000120  75 62 66 69 65 6c 64 3e  0a 20 20 20 20 20 20 3c  |ubfield>.      <|
00000130  73 75 62 66 69 65 6c 64  20 63 6f 64 65 3d 22 62  |subfield code="b|
00000140  22 3e 49 6e 73 74 69 74  75 74 20 66 75 cc 88 72  |">Institut fu..r|
00000150  20 53 6f 7a 69 61 6c 66  6f 72 73 63 68 75 6e 67  | Sozialforschung|
00000160  3c 2f 73 75 62 66 69 65  6c 64 3e 0a 20 20 20 20  |</subfield>.    |
00000170  3c 2f 64 61 74 61 66 69  65 6c 64 3e 0a 20 20 3c  |</datafield>.  <|
00000180  2f 72 65 63 6f 72 64 3e  0a 3c 2f 63 6f 6c 6c 65  |/record>.</colle|
00000190  63 74 69 6f 6e 3e                                 |ction>|
```

### No transliteration (default, NFD → NFC)

```bash
$ pica filter --reduce "029A" "003@.0?" tests/data/004732650.dat.gz  | \
       pica xml --translit nfc | hexdump -C
00000000  3c 3f 78 6d 6c 20 76 65  72 73 69 6f 6e 3d 22 31  |<?xml version="1|
00000010  2e 30 22 20 65 6e 63 6f  64 69 6e 67 3d 22 75 74  |.0" encoding="ut|
00000020  66 2d 38 22 3f 3e 0a 3c  63 6f 6c 6c 65 63 74 69  |f-8"?>.<collecti|
00000030  6f 6e 20 78 6d 6c 6e 73  3d 22 69 6e 66 6f 3a 73  |on xmlns="info:s|
00000040  72 77 2f 73 63 68 65 6d  61 2f 35 2f 70 69 63 61  |rw/schema/5/pica|
00000050  58 4d 4c 2d 76 31 2e 30  22 20 78 6d 6c 6e 73 3a  |XML-v1.0" xmlns:|
00000060  78 73 3d 22 68 74 74 70  3a 2f 2f 77 77 77 2e 77  |xs="http://www.w|
00000070  33 2e 6f 72 67 2f 32 30  30 31 2f 58 4d 4c 53 63  |3.org/2001/XMLSc|
00000080  68 65 6d 61 22 20 74 61  72 67 65 74 4e 61 6d 65  |hema" targetName|
00000090  73 70 61 63 65 3d 22 69  6e 66 6f 3a 73 72 77 2f  |space="info:srw/|
000000a0  73 63 68 65 6d 61 2f 35  2f 70 69 63 61 58 4d 4c  |schema/5/picaXML|
000000b0  2d 76 31 2e 30 22 3e 0a  20 20 3c 72 65 63 6f 72  |-v1.0">.  <recor|
000000c0  64 3e 0a 20 20 20 20 3c  64 61 74 61 66 69 65 6c  |d>.    <datafiel|
000000d0  64 20 74 61 67 3d 22 30  32 39 41 22 3e 0a 20 20  |d tag="029A">.  |
000000e0  20 20 20 20 3c 73 75 62  66 69 65 6c 64 20 63 6f  |    <subfield co|
000000f0  64 65 3d 22 61 22 3e 47  6f 65 74 68 65 2d 55 6e  |de="a">Goethe-Un|
00000100  69 76 65 72 73 69 74 c3  a4 74 20 46 72 61 6e 6b  |iversit..t Frank|
00000110  66 75 72 74 20 61 6d 20  4d 61 69 6e 3c 2f 73 75  |furt am Main</su|
00000120  62 66 69 65 6c 64 3e 0a  20 20 20 20 20 20 3c 73  |bfield>.      <s|
00000130  75 62 66 69 65 6c 64 20  63 6f 64 65 3d 22 62 22  |ubfield code="b"|
00000140  3e 49 6e 73 74 69 74 75  74 20 66 c3 bc 72 20 53  |>Institut f..r S|
00000150  6f 7a 69 61 6c 66 6f 72  73 63 68 75 6e 67 3c 2f  |ozialforschung</|
00000160  73 75 62 66 69 65 6c 64  3e 0a 20 20 20 20 3c 2f  |subfield>.    </|
00000170  64 61 74 61 66 69 65 6c  64 3e 0a 20 20 3c 2f 72  |datafield>.  </r|
00000180  65 63 6f 72 64 3e 0a 3c  2f 63 6f 6c 6c 65 63 74  |ecord>.</collect|
00000190  69 6f 6e 3e                                       |ion>|
```

### No transliteration (default, NFD → NFD)
(transliteration is idempotent)

```bash
$ pica filter --reduce "029A" "003@.0?" tests/data/004732650.dat.gz  | \
       pica xml --translit nfd | hexdump -C
00000000  3c 3f 78 6d 6c 20 76 65  72 73 69 6f 6e 3d 22 31  |<?xml version="1|
00000010  2e 30 22 20 65 6e 63 6f  64 69 6e 67 3d 22 75 74  |.0" encoding="ut|
00000020  66 2d 38 22 3f 3e 0a 3c  63 6f 6c 6c 65 63 74 69  |f-8"?>.<collecti|
00000030  6f 6e 20 78 6d 6c 6e 73  3d 22 69 6e 66 6f 3a 73  |on xmlns="info:s|
00000040  72 77 2f 73 63 68 65 6d  61 2f 35 2f 70 69 63 61  |rw/schema/5/pica|
00000050  58 4d 4c 2d 76 31 2e 30  22 20 78 6d 6c 6e 73 3a  |XML-v1.0" xmlns:|
00000060  78 73 3d 22 68 74 74 70  3a 2f 2f 77 77 77 2e 77  |xs="http://www.w|
00000070  33 2e 6f 72 67 2f 32 30  30 31 2f 58 4d 4c 53 63  |3.org/2001/XMLSc|
00000080  68 65 6d 61 22 20 74 61  72 67 65 74 4e 61 6d 65  |hema" targetName|
00000090  73 70 61 63 65 3d 22 69  6e 66 6f 3a 73 72 77 2f  |space="info:srw/|
000000a0  73 63 68 65 6d 61 2f 35  2f 70 69 63 61 58 4d 4c  |schema/5/picaXML|
000000b0  2d 76 31 2e 30 22 3e 0a  20 20 3c 72 65 63 6f 72  |-v1.0">.  <recor|
000000c0  64 3e 0a 20 20 20 20 3c  64 61 74 61 66 69 65 6c  |d>.    <datafiel|
000000d0  64 20 74 61 67 3d 22 30  32 39 41 22 3e 0a 20 20  |d tag="029A">.  |
000000e0  20 20 20 20 3c 73 75 62  66 69 65 6c 64 20 63 6f  |    <subfield co|
000000f0  64 65 3d 22 61 22 3e 47  6f 65 74 68 65 2d 55 6e  |de="a">Goethe-Un|
00000100  69 76 65 72 73 69 74 61  cc 88 74 20 46 72 61 6e  |iversita..t Fran|
00000110  6b 66 75 72 74 20 61 6d  20 4d 61 69 6e 3c 2f 73  |kfurt am Main</s|
00000120  75 62 66 69 65 6c 64 3e  0a 20 20 20 20 20 20 3c  |ubfield>.      <|
00000130  73 75 62 66 69 65 6c 64  20 63 6f 64 65 3d 22 62  |subfield code="b|
00000140  22 3e 49 6e 73 74 69 74  75 74 20 66 75 cc 88 72  |">Institut fu..r|
00000150  20 53 6f 7a 69 61 6c 66  6f 72 73 63 68 75 6e 67  | Sozialforschung|
00000160  3c 2f 73 75 62 66 69 65  6c 64 3e 0a 20 20 20 20  |</subfield>.    |
00000170  3c 2f 64 61 74 61 66 69  65 6c 64 3e 0a 20 20 3c  |</datafield>.  <|
00000180  2f 72 65 63 6f 72 64 3e  0a 3c 2f 63 6f 6c 6c 65  |/record>.</colle|
00000190  63 74 69 6f 6e 3e                                 |ction>|
```