### PR TITLE
Add `--translit` option to `print` command

### DIFF
--- a/src/bin/pica/main.rs
+++ b/src/bin/pica/main.rs
@@ -10,6 +10,7 @@ mod cmds;
 mod common;
 mod config;
 mod macros;
+mod translit;
 mod util;
 
 use config::Config;

--- a/src/bin/pica/translit.rs
+++ b/src/bin/pica/translit.rs
@@ -1,0 +1,45 @@
+use unicode_normalization::UnicodeNormalization;
+
+pub(crate) fn translit_maybe(value: &str, translit: Option<&str>) -> String {
+    match translit {
+        Some("nfc") => value.nfc().collect::<String>(),
+        Some("nfkc") => value.nfkc().collect::<String>(),
+        Some("nfd") => value.nfd().collect::<String>(),
+        Some("nfkd") => value.nfkd().collect::<String>(),
+        None => value.to_string(),
+        _ => panic!("Unknown unicode normal form"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_translit_maybe() {
+        let expected = vec![
+            // Input = NFC
+            ("Am\u{0e9}lie", None, "Am\u{0e9}lie"), // no-translit
+            ("Am\u{0e9}lie", Some("nfc"), "Am\u{0e9}lie"), // NFC -> NFC
+            ("Am\u{0e9}lie", Some("nfkc"), "Am\u{0e9}lie"), // NFC -> NFKC
+            ("Am\u{0e9}lie", Some("nfd"), "Ame\u{301}lie"), // NFC -> NFD
+            ("Am\u{0e9}lie", Some("nfkd"), "Ame\u{301}lie"), // NFC -> NFD
+            // Input = NFD
+            ("Ame\u{301}lie", None, "Ame\u{301}lie"), // no-translit
+            ("Ame\u{301}lie", Some("nfd"), "Ame\u{301}lie"), // NFD -> NFD
+            ("Ame\u{301}lie", Some("nfkd"), "Ame\u{301}lie"), // NFD -> NFD
+            ("Ame\u{301}lie", Some("nfc"), "Am\u{0e9}lie"), // NFD -> NFC
+            ("Ame\u{301}lie", Some("nfkc"), "Am\u{0e9}lie"), // NFD -> NFC
+        ];
+
+        for (input, translit, output) in expected {
+            assert_eq!(translit_maybe(input, translit), output);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Unknown unicode normal form")]
+    fn test_translit_maybe_panic() {
+        translit_maybe("foo", Some("foo"));
+    }
+}

--- a/tests/data/004732650-nfc.txt
+++ b/tests/data/004732650-nfc.txt
@@ -1,0 +1,2 @@
+029A $aGoethe-Universität Frankfurt am Main$bInstitut für Sozialforschung
+

--- a/tests/data/004732650-nfd.txt
+++ b/tests/data/004732650-nfd.txt
@@ -1,0 +1,2 @@
+029A $aGoethe-Universität Frankfurt am Main$bInstitut für Sozialforschung
+

--- a/tests/pica/print.rs
+++ b/tests/pica/print.rs
@@ -245,6 +245,70 @@ fn pica_print_write_output() -> TestResult {
 }
 
 #[test]
+fn pica_print_translit() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("print")
+        .arg("tests/data/004732650-reduced.dat.gz")
+        .assert();
+
+    let expected = read_to_string("tests/data/004732650-nfd.txt").unwrap();
+    let expected = if cfg!(windows) {
+        expected.replace('\r', "")
+    } else {
+        expected
+    };
+
+    assert.success().stdout(expected.to_string());
+
+    let expected = vec![
+        ("nfd", "tests/data/004732650-nfd.txt"),
+        ("nfkd", "tests/data/004732650-nfd.txt"),
+        ("nfc", "tests/data/004732650-nfc.txt"),
+        ("nfkc", "tests/data/004732650-nfc.txt"),
+    ];
+
+    for (translit, output) in expected {
+        let mut cmd = Command::cargo_bin("pica")?;
+        let assert = cmd
+            .arg("print")
+            .arg("--translit")
+            .arg(translit)
+            .arg("tests/data/004732650-reduced.dat.gz")
+            .assert();
+
+        let expected = read_to_string(output).unwrap();
+        let expected = if cfg!(windows) {
+            expected.replace('\r', "")
+        } else {
+            expected
+        };
+
+        assert.success().stdout(expected.to_string());
+    }
+
+    let expected = vec![
+        ("nfd", "029A $aGoethe-Universita\u{308}t"),
+        ("nfkd", "029A $aGoethe-Universita\u{308}t"),
+        ("nfc", "029A $aGoethe-Universität"),
+        ("nfkc", "029A $aGoethe-Universität"),
+    ];
+
+    for (translit, prefix) in expected {
+        let mut cmd = Command::cargo_bin("pica")?;
+        let assert = cmd
+            .arg("print")
+            .arg("--translit")
+            .arg(translit)
+            .arg("tests/data/004732650-reduced.dat.gz")
+            .assert();
+
+        assert.success().stdout(predicate::str::starts_with(prefix));
+    }
+    Ok(())
+}
+
+#[test]
 fn pica_print_skip_invalid() -> TestResult {
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd

--- a/tests/pica/print.rs
+++ b/tests/pica/print.rs
@@ -259,7 +259,7 @@ fn pica_print_translit() -> TestResult {
         expected
     };
 
-    assert.success().stdout(expected.to_string());
+    assert.success().stdout(expected);
 
     let expected = vec![
         ("nfd", "tests/data/004732650-nfd.txt"),
@@ -284,7 +284,7 @@ fn pica_print_translit() -> TestResult {
             expected
         };
 
-        assert.success().stdout(expected.to_string());
+        assert.success().stdout(expected);
     }
 
     let expected = vec![


### PR DESCRIPTION
## Example

- [Unicode Character “ä” (U+00E4)](https://www.compart.com/en/unicode/U+00E4), UTF8-Encoding: 0xC3 0xA4, Decomposed: [a (U+0061)](https://www.compart.com/en/unicode/U+0061) - [◌̈ (U+0308)](https://www.compart.com/en/unicode/U+0308)
- [Unicode Character “a” (U+0061)](https://www.compart.com/en/unicode/U+0061), UTF8-Encoding: 0x61
- [Unicode Character “◌̈” (U+0308)](https://www.compart.com/en/unicode/U+0308), UTF8-Encoding: 0xCC 0x88

### No transliteration (default, NFD → NFD)

```bash
$ pica filter --reduce "029A" "003@.0?" tests/data/004732650.dat.gz  | \
       pica print | hexdump -C
00000000  30 32 39 41 20 24 61 47  6f 65 74 68 65 2d 55 6e  |029A $aGoethe-Un|
00000010  69 76 65 72 73 69 74 61  cc 88 74 20 46 72 61 6e  |iversita..t Fran|
00000020  6b 66 75 72 74 20 61 6d  20 4d 61 69 6e 24 62 49  |kfurt am Main$bI|
00000030  6e 73 74 69 74 75 74 20  66 75 cc 88 72 20 53 6f  |nstitut fu..r So|
00000040  7a 69 61 6c 66 6f 72 73  63 68 75 6e 67 0a 0a     |zialforschung..|

```

### No transliteration (default, NFD → NFC)

```bash
$ pica filter --reduce "029A" "003@.0?" tests/data/004732650.dat.gz  | \
       pica print --translit nfc | hexdump -C
00000000  30 32 39 41 20 24 61 47  6f 65 74 68 65 2d 55 6e  |029A $aGoethe-Un|
00000010  69 76 65 72 73 69 74 c3  a4 74 20 46 72 61 6e 6b  |iversit..t Frank|
00000020  66 75 72 74 20 61 6d 20  4d 61 69 6e 24 62 49 6e  |furt am Main$bIn|
00000030  73 74 69 74 75 74 20 66  c3 bc 72 20 53 6f 7a 69  |stitut f..r Sozi|
00000040  61 6c 66 6f 72 73 63 68  75 6e 67 0a 0a           |alforschung..|
```

### No transliteration (default, NFD → NFD)
(transliteration is idempotent)

```bash
$ pica filter --reduce "029A" "003@.0?" tests/data/004732650.dat.gz  | \
       pica print --translit nfd | hexdump -C
00000000  30 32 39 41 20 24 61 47  6f 65 74 68 65 2d 55 6e  |029A $aGoethe-Un|
00000010  69 76 65 72 73 69 74 61  cc 88 74 20 46 72 61 6e  |iversita..t Fran|
00000020  6b 66 75 72 74 20 61 6d  20 4d 61 69 6e 24 62 49  |kfurt am Main$bI|
00000030  6e 73 74 69 74 75 74 20  66 75 cc 88 72 20 53 6f  |nstitut fu..r So|
00000040  7a 69 61 6c 66 6f 72 73  63 68 75 6e 67 0a 0a     |zialforschung..|
```