### PR TITLE
Allow `cat` command to read from `stdin`

### DIFF
--- a/src/bin/pica/cmds/cat.rs
+++ b/src/bin/pica/cmds/cat.rs
@@ -59,7 +59,7 @@ pub(crate) fn run(args: &CliArgs, config: &Config) -> CliResult<()> {
 
     let filenames = args
         .values_of_t::<OsString>("filenames")
-        .unwrap_or(vec![OsString::from("-")]);
+        .unwrap_or_else(|_| vec![OsString::from("-")]);
 
     for filename in filenames {
         let builder = ReaderBuilder::new().skip_invalid(skip_invalid);

--- a/src/bin/pica/cmds/cat.rs
+++ b/src/bin/pica/cmds/cat.rs
@@ -1,8 +1,11 @@
+use std::ffi::OsString;
+use std::io::{self, Read};
+
 use crate::config::Config;
 use crate::util::{App, CliArgs, CliResult};
 use crate::{gzip_flag, skip_invalid_flag};
 use clap::Arg;
-use pica::{PicaWriter, ReaderBuilder, WriterBuilder};
+use pica::{PicaWriter, Reader, ReaderBuilder, WriterBuilder};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -35,7 +38,15 @@ pub(crate) fn cli() -> App {
                 .value_name("file")
                 .help("Write output to <file> instead of stdout."),
         )
-        .arg(Arg::new("filenames").multiple_values(true).required(true))
+        .arg(
+            Arg::new("filenames")
+                .help(
+                    "Concatenate all records from <filenames> into \
+                    one stream. With no <filenames>, or when a filename \
+                    is -, read from standard input (stdint).",
+                )
+                .multiple_values(true),
+        )
 }
 
 pub(crate) fn run(args: &CliArgs, config: &Config) -> CliResult<()> {
@@ -46,10 +57,16 @@ pub(crate) fn run(args: &CliArgs, config: &Config) -> CliResult<()> {
         .gzip(gzip_compression)
         .from_path_or_stdout(args.value_of("output"))?;
 
-    for filename in args.values_of("filenames").unwrap() {
-        let mut reader = ReaderBuilder::new()
-            .skip_invalid(skip_invalid)
-            .from_path(filename)?;
+    let filenames = args
+        .values_of_t::<OsString>("filenames")
+        .unwrap_or(vec![OsString::from("-")]);
+
+    for filename in filenames {
+        let builder = ReaderBuilder::new().skip_invalid(skip_invalid);
+        let mut reader: Reader<Box<dyn Read>> = match filename.to_str() {
+            Some("-") => builder.from_reader(Box::new(io::stdin())),
+            _ => builder.from_path(filename)?,
+        };
 
         for result in reader.byte_records() {
             writer.write_byte_record(&result?)?;

--- a/tests/pica/cat.rs
+++ b/tests/pica/cat.rs
@@ -43,6 +43,51 @@ fn pica_cat_multiple_files() -> TestResult {
 }
 
 #[test]
+fn pica_cat_stdin() -> TestResult {
+    let data = read_to_string("tests/data/1004916019.dat").unwrap();
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd.arg("cat").write_stdin(data).assert();
+
+    let expected =
+        predicate::path::eq_file(Path::new("tests/data/1004916019.dat"));
+
+    assert
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(expected);
+
+    let data = read_to_string("tests/data/1004916019.dat").unwrap();
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd.arg("cat").arg("-").write_stdin(data).assert();
+
+    let expected =
+        predicate::path::eq_file(Path::new("tests/data/1004916019.dat"));
+
+    assert
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(expected);
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("cat")
+        .arg("--skip-invalid")
+        .arg("-")
+        .arg("tests/data/1004916019.dat")
+        .write_stdin("foo")
+        .assert();
+
+    let expected =
+        predicate::path::eq_file(Path::new("tests/data/1004916019.dat"));
+
+    assert
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(expected);
+    Ok(())
+}
+
+#[test]
 fn pica_cat_read_gzip() -> TestResult {
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd


### PR DESCRIPTION
With this change, the `cat` command can read form standard input (`stdin`). This is usefull when the output of an other process must be concatenated with one or multiple files. When no filenames are given as arguments or a filename is equal to `-`, the commands reads from `stdin`.

## Example

```bash
$ pica filter -s "003@.0 == '0123456789X'" | pica cat - file1.dat file2.dat.gz file3.dat -o result.dat
``` 