### PR TITLE
Add `--tee` option to `cat` command

### DIFF
--- a/tests/pica/cat.rs
+++ b/tests/pica/cat.rs
@@ -129,6 +129,30 @@ fn pica_cat_write_gzip() -> TestResult {
 }
 
 #[test]
+fn pica_cat_tee() -> TestResult {
+    let filename = Builder::new().suffix(".dat").tempfile()?;
+    let filename_str = filename.path();
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("cat")
+        .arg("--tee")
+        .arg(filename_str)
+        .arg("tests/data/1004916019.dat")
+        .assert();
+
+    let expected =
+        predicate::path::eq_file(Path::new("tests/data/1004916019.dat"));
+    assert.success().stdout(expected);
+
+    let expected =
+        predicate::path::eq_file(Path::new("tests/data/1004916019.dat"));
+    assert!(expected.eval(Path::new(filename_str)));
+
+    Ok(())
+}
+
+#[test]
 fn pica_cat_skip_invalid() -> TestResult {
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd


### PR DESCRIPTION
This change adds the `--tee` option to the `cat` command. This options acts like the linux `tee` command. If this option is set, the output of the `cat` command will be written to a file (`tee`'s value) and to the standard output (`stdout`). This feature is usefull when the output is needed by a next command (separate call) *and* the output is processed by a other command (in a pipeline).

The option `--tee` cannot be used with `--output`.

## Example

```bash
$ pica cat --skip-invalid --tee gnd.dat partitions/T*.dat | pica filter "002@.0 =^ 'Ts'" \
       --output gnd_subject_terms.dat
$ pica filter "002@.0 =^ 'Tp'" gnd.dat -o gnd_persons.dat
```