### PR TITLE
Add `--append` option to `cat` command

### DIFF
--- a/src/bin/pica/cmds/cat.rs
+++ b/src/bin/pica/cmds/cat.rs
@@ -32,6 +32,11 @@ pub(crate) fn cli() -> Command {
                 .requires("output"),
         )
         .arg(
+            Arg::new("append")
+                .long("--append")
+                .help("Append to the given <file>, do not overwrite.")
+       )
+        .arg(
             Arg::new("tee")
             .help(
                 "This option allows to write simultaneously to <file> and to \
@@ -62,15 +67,18 @@ pub(crate) fn cli() -> Command {
 pub(crate) fn run(args: &CliArgs, config: &Config) -> CliResult<()> {
     let skip_invalid = skip_invalid_flag!(args, config.cat, config.global);
     let gzip_compression = gzip_flag!(args, config.cat);
+    let append = args.is_present("append");
 
     let mut writer: Box<dyn PicaWriter> = WriterBuilder::new()
         .gzip(gzip_compression)
+        .append(append)
         .from_path_or_stdout(args.value_of("output"))?;
 
     let mut tee_writer = match args.value_of("tee") {
         Some(path) => Some(
             WriterBuilder::new()
                 .gzip(gzip_compression)
+                .append(append)
                 .from_path(path)?,
         ),
         None => None,

--- a/tests/pica/cat.rs
+++ b/tests/pica/cat.rs
@@ -153,6 +153,95 @@ fn pica_cat_tee() -> TestResult {
 }
 
 #[test]
+fn pica_cat_append() -> TestResult {
+    // --output
+    let filename = Builder::new().suffix(".dat").tempfile()?;
+    let filename_str = filename.path();
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("cat")
+        .arg("tests/data/1004916019.dat")
+        .arg("--output")
+        .arg(filename_str)
+        .assert();
+
+    assert
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::is_empty());
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("cat")
+        .arg("--append")
+        .arg("tests/data/000009229.dat")
+        .arg("--output")
+        .arg(filename_str)
+        .assert();
+
+    assert
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::is_empty());
+
+    let expected = format!(
+        "{}{}",
+        read_to_string("tests/data/1004916019.dat").unwrap(),
+        read_to_string("tests/data/000009229.dat").unwrap()
+    );
+
+    assert_eq!(expected, read_to_string(filename_str)?);
+
+    // --tee
+    let filename = Builder::new().suffix(".dat").tempfile()?;
+    let filename_str = filename.path();
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("cat")
+        .arg("--tee")
+        .arg(filename_str)
+        .arg("tests/data/1004916019.dat")
+        .assert();
+
+    let expected =
+        predicate::path::eq_file(Path::new("tests/data/1004916019.dat"));
+
+    assert
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(expected);
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("cat")
+        .arg("--append")
+        .arg("--tee")
+        .arg(filename_str)
+        .arg("tests/data/000009229.dat")
+        .assert();
+
+    let expected =
+        predicate::path::eq_file(Path::new("tests/data/000009229.dat"));
+
+    assert
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(expected);
+
+    let expected = format!(
+        "{}{}",
+        read_to_string("tests/data/1004916019.dat").unwrap(),
+        read_to_string("tests/data/000009229.dat").unwrap()
+    );
+
+    assert_eq!(expected, read_to_string(filename_str)?);
+
+    Ok(())
+}
+
+#[test]
 fn pica_cat_skip_invalid() -> TestResult {
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd


### PR DESCRIPTION
This change adds the `--append` option to the `cat` command. If this flag is set, the output will be appended to the file (if exists), otherwise the file will be crated. The flag is disabled by default and must be set explicitly. The behaviour of the `--output` value as well as the `--tee` value is affected by this flag.

The flag has no effect when writing to standard output (`stdout`).

## Example

```bash
$ pica cat partitions/Ts*.dat -o A.dat
$ pica cat partitions/Tp*.dat --append -o A.dat # A.dat contains all records from Ts*.dat and Tp*.dat
```