### PR TITLE
Rename `completion` command to `completions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ cargo install --git https://github.com/deutsche-nationalbibliothek/pica-rs --t
 | Command                 | Stability | Desciption                                                        |
 |-------------------------|-----------|-------------------------------------------------------------------|
 | [cat](#cat)             | beta      | concatenate records from multiple files                           |
-| completion              | beta      | generate a completions file for bash, fish or zsh                 |
+| completions             | beta      | generate a completions file for bash, fish or zsh                 |
 | [count](#count)         | unstable  | count records, fields and subfields                               |
 | [filter](#filter)       | beta      | filter records by query expressions                               |
 | [frequency](#frequency) | beta      | compute a frequency table of a subfield                           |

--- a/docs/book/src/de/SUMMARY.md
+++ b/docs/book/src/de/SUMMARY.md
@@ -7,7 +7,7 @@
 - [Installation](guide/installation.md)
 - [Kommandos]()
     - [cat](guide/cmds/cat.md)
-    - [completion]()
+    - [completions]()
     - [count]()
     - [filter]()
     - [frequency]()

--- a/src/bin/pica/cmds/completions.rs
+++ b/src/bin/pica/cmds/completions.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::{self, Write};
 
 pub(crate) fn cli() -> Command {
-    Command::new("completion")
+    Command::new("completions")
         .about("Generate a completions file for Bash, Fish or ZSH shell.")
         .arg(
             Arg::new("shell")

--- a/src/bin/pica/cmds/mod.rs
+++ b/src/bin/pica/cmds/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod cat;
-pub(crate) mod completion;
+pub(crate) mod completions;
 pub(crate) mod count;
 pub(crate) mod filter;
 pub(crate) mod frequency;
@@ -18,7 +18,7 @@ use crate::util::Command;
 pub(crate) fn subcmds() -> Vec<Command> {
     vec![
         cat::cli(),
-        completion::cli(),
+        completions::cli(),
         count::cli(),
         filter::cli(),
         frequency::cli(),

--- a/src/bin/pica/main.rs
+++ b/src/bin/pica/main.rs
@@ -27,7 +27,7 @@ fn run() -> CliResult<()> {
 
     match name {
         "cat" => cmds::cat::run(args, &config),
-        "completion" => cmds::completion::run(args, &mut app),
+        "completions" => cmds::completions::run(args, &mut app),
         "count" => cmds::count::run(args, &config),
         "filter" => cmds::filter::run(args, &config),
         "frequency" => cmds::frequency::run(args, &config),

--- a/tests/pica/completions.rs
+++ b/tests/pica/completions.rs
@@ -11,7 +11,7 @@ fn pica_bash_completion() -> TestResult {
 
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd
-        .arg("completion")
+        .arg("completions")
         .arg("bash")
         .arg("--output")
         .arg(filename_str)
@@ -20,7 +20,7 @@ fn pica_bash_completion() -> TestResult {
     assert!(predicates::path::is_file().eval(filename_str));
 
     let mut cmd = Command::cargo_bin("pica")?;
-    let assert = cmd.arg("completion").arg("bash").assert();
+    let assert = cmd.arg("completions").arg("bash").assert();
     assert
         .success()
         .stdout(predicate::path::eq_file(filename_str));
@@ -35,7 +35,7 @@ fn pica_fish_completion() -> TestResult {
 
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd
-        .arg("completion")
+        .arg("completions")
         .arg("fish")
         .arg("--output")
         .arg(filename_str)
@@ -44,7 +44,7 @@ fn pica_fish_completion() -> TestResult {
     assert!(predicates::path::is_file().eval(filename_str));
 
     let mut cmd = Command::cargo_bin("pica")?;
-    let assert = cmd.arg("completion").arg("fish").assert();
+    let assert = cmd.arg("completions").arg("fish").assert();
     assert
         .success()
         .stdout(predicate::path::eq_file(filename_str));
@@ -59,7 +59,7 @@ fn pica_zsh_completion() -> TestResult {
 
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd
-        .arg("completion")
+        .arg("completions")
         .arg("zsh")
         .arg("--output")
         .arg(filename_str)
@@ -68,7 +68,7 @@ fn pica_zsh_completion() -> TestResult {
     assert!(predicates::path::is_file().eval(filename_str));
 
     let mut cmd = Command::cargo_bin("pica")?;
-    let assert = cmd.arg("completion").arg("zsh").assert();
+    let assert = cmd.arg("completions").arg("zsh").assert();
     assert
         .success()
         .stdout(predicate::path::eq_file(filename_str));

--- a/tests/pica/mod.rs
+++ b/tests/pica/mod.rs
@@ -3,7 +3,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 
 mod cat;
-mod completion;
+mod completions;
 mod count;
 mod filter;
 mod frequency;


### PR DESCRIPTION
This PR changes the name of the `completion` command to `completions`, which is used more often.