### PR TITLE
Change output format of `count` command

### DIFF
--- a/tests/data/dump_cnt.csv
+++ b/tests/data/dump_cnt.csv
@@ -1,3 +1,2 @@
-records,7
-fields,247
-subfields,549
+records,fields,subfields
+7,247,549

--- a/tests/data/dump_cnt.tsv
+++ b/tests/data/dump_cnt.tsv
@@ -1,3 +1,2 @@
-records	7
-fields	247
-subfields	549
+records	fields	subfields
+7	247	549

--- a/tests/data/dump_cnt.txt
+++ b/tests/data/dump_cnt.txt
@@ -1,3 +1,3 @@
-records 7
-fields 247
-subfields 549
+records: 7
+fields: 247
+subfields: 549

--- a/tests/data/invalid_cnt.txt
+++ b/tests/data/invalid_cnt.txt
@@ -1,3 +1,3 @@
-records 0
-fields 0
-subfields 0
+records: 0
+fields: 0
+subfields: 0

--- a/tests/pica/count.rs
+++ b/tests/pica/count.rs
@@ -167,6 +167,39 @@ fn pica_print_write_output() -> TestResult {
 }
 
 #[test]
+fn pica_print_no_header() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("count")
+        .arg("--skip-invalid")
+        .arg("--csv")
+        .arg("--no-header")
+        .arg("tests/data/dump.dat.gz")
+        .assert();
+
+    assert
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout("7,247,549\n");
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("count")
+        .arg("--skip-invalid")
+        .arg("--tsv")
+        .arg("--no-header")
+        .arg("tests/data/dump.dat.gz")
+        .assert();
+
+    assert
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout("7\t247\t549\n");
+
+    Ok(())
+}
+
+#[test]
 fn pica_count_skip_invalid() -> TestResult {
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd

--- a/tests/pica/count.rs
+++ b/tests/pica/count.rs
@@ -42,7 +42,7 @@ fn pica_count_multiple_files() -> TestResult {
     assert
         .success()
         .stderr(predicate::str::is_empty())
-        .stdout("records 2\nfields 55\nsubfields 114\n");
+        .stdout("records: 2\nfields: 55\nsubfields: 114\n");
 
     Ok(())
 }
@@ -56,7 +56,7 @@ fn pica_count_stdin() -> TestResult {
     assert
         .success()
         .stderr(predicate::str::is_empty())
-        .stdout("records 1\nfields 22\nsubfields 43\n");
+        .stdout("records: 1\nfields: 22\nsubfields: 43\n");
 
     let data = read_to_string("tests/data/1004916019.dat").unwrap();
     let mut cmd = Command::cargo_bin("pica")?;
@@ -65,7 +65,7 @@ fn pica_count_stdin() -> TestResult {
     assert
         .success()
         .stderr(predicate::str::is_empty())
-        .stdout("records 1\nfields 22\nsubfields 43\n");
+        .stdout("records: 1\nfields: 22\nsubfields: 43\n");
 
     let data = read_to_string("tests/data/1004916019.dat").unwrap();
     let mut cmd = Command::cargo_bin("pica")?;
@@ -79,7 +79,7 @@ fn pica_count_stdin() -> TestResult {
     assert
         .success()
         .stderr(predicate::str::is_empty())
-        .stdout("records 2\nfields 55\nsubfields 114\n");
+        .stdout("records: 2\nfields: 55\nsubfields: 114\n");
 
     Ok(())
 }


### PR DESCRIPTION
This PR changes the output format of the `count` command:

- in text output a colon is append to the label
- in csv/tsv-output the rows and columns are transposed
- With the `--no-header` flag no header will be written

## Examples

```bash
$ pica count -s tests/data/dump.dat.gz
records: 7
fields: 247
subfields: 549
```

```bash
$ pica count -s --csv tests/data/dump.dat.gz
records,fields,subfields
7,247,549
```

```bash
$ pica count -s --csv --no-header tests/data/dump.dat.gz
7,247,549
```