### PR TITLE
Allow `count` command to print single values

### DIFF
--- a/src/bin/pica/cmds/count.rs
+++ b/src/bin/pica/cmds/count.rs
@@ -26,6 +26,24 @@ pub(crate) fn cli() -> Command {
                 .help("skip invalid records"),
         )
         .arg(
+            Arg::new("records")
+                .long("--records")
+                .help("Prints only the number of records.")
+                .conflicts_with_all(&["tsv", "csv", "no-header", "fields", "subfields"])
+        )
+        .arg(
+            Arg::new("fields")
+                .long("--fields")
+                .help("Prints only the number of fields.")
+                .conflicts_with_all(&["tsv", "csv", "no-header", "records", "subfields"])
+        )
+        .arg(
+            Arg::new("subfields")
+                .long("--subfields")
+                .help("Prints only the number of subfields.")
+                .conflicts_with_all(&["tsv", "csv", "no-header", "records", "fields"])
+        )
+        .arg(
             Arg::new("tsv")
                 .long("tsv")
                 .help("use tabs as delimiter")
@@ -103,7 +121,13 @@ pub(crate) fn run(args: &CliArgs, config: &Config) -> CliResult<()> {
         }
     }
 
-    if args.is_present("csv") {
+    if args.is_present("records") {
+        writeln!(writer, "{}", records)?;
+    } else if args.is_present("fields") {
+        writeln!(writer, "{}", fields)?;
+    } else if args.is_present("subfields") {
+        writeln!(writer, "{}", subfields)?;
+    } else if args.is_present("csv") {
         if !args.is_present("no-header") {
             writeln!(writer, "records,fields,subfields")?;
         }

--- a/tests/pica/count.rs
+++ b/tests/pica/count.rs
@@ -248,6 +248,53 @@ fn pica_print_no_header() -> TestResult {
 }
 
 #[test]
+fn pica_print_single_value() -> TestResult {
+    // --records
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("count")
+        .arg("--skip-invalid")
+        .arg("--records")
+        .arg("tests/data/dump.dat.gz")
+        .assert();
+
+    assert
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout("7\n");
+
+    // --fields
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("count")
+        .arg("--skip-invalid")
+        .arg("--fields")
+        .arg("tests/data/dump.dat.gz")
+        .assert();
+
+    assert
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout("247\n");
+
+    // --subfields
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("count")
+        .arg("--skip-invalid")
+        .arg("--subfields")
+        .arg("tests/data/dump.dat.gz")
+        .assert();
+
+    assert
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout("549\n");
+
+    Ok(())
+}
+
+#[test]
 fn pica_count_skip_invalid() -> TestResult {
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd


### PR DESCRIPTION
This change adds the flags `--records`, `--fields` and `--subfields`. If one of these flags is set, only the requested value will be printed on the terminal. These flags are mutual exclusive, setting more than one of these flags will result in an error. Also, the combination with the flags `--no-header`, `--csv` or `--tsv` is not allowed.

## Example

```bash
$ pica count -s --records tests/data/dump.dat.gz
7

$ pica count -s --fields tests/data/dump.dat.gz
247

$ pica count -s --subfields tests/data/dump.dat.gz
549
```