### PR TITLE
Fix write to existing files

### DIFF
--- a/src/bin/pica/cmds/count.rs
+++ b/src/bin/pica/cmds/count.rs
@@ -85,13 +85,15 @@ pub(crate) fn cli() -> Command {
 
 pub(crate) fn run(args: &CliArgs, config: &Config) -> CliResult<()> {
     let skip_invalid = skip_invalid_flag!(args, config.count, config.global);
+    let append = args.is_present("append");
 
     let mut writer: Box<dyn Write> = match args.value_of("output") {
         Some(path) => Box::new(
             OpenOptions::new()
                 .write(true)
                 .create(true)
-                .append(args.is_present("append"))
+                .truncate(!append)
+                .append(append)
                 .open(path)?,
         ),
         None => Box::new(io::stdout()),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -97,6 +97,7 @@ impl WriterBuilder {
         let file = OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(!self.append)
             .append(self.append)
             .open(path)?;
 

--- a/tests/pica/print.rs
+++ b/tests/pica/print.rs
@@ -291,6 +291,54 @@ add-spaces = true
 }
 
 #[test]
+fn pica_print_gh438() -> TestResult {
+    let filename = Builder::new().suffix(".txt").tempfile()?;
+    let filename_str = filename.path();
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("print")
+        .arg("--skip-invalid")
+        .arg("--output")
+        .arg(filename_str)
+        .arg("tests/data/dump.dat.gz")
+        .assert();
+    assert.success().stdout(predicate::str::is_empty());
+
+    let expected = read_to_string("tests/data/dump.txt").unwrap();
+    let expected = if cfg!(windows) {
+        expected.replace('\r', "")
+    } else {
+        expected
+    };
+
+    let actual = read_to_string(filename_str).unwrap();
+    assert_eq!(expected, actual);
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("print")
+        .arg("--skip-invalid")
+        .arg("--output")
+        .arg(filename_str)
+        .arg("tests/data/1004916019.dat")
+        .assert();
+    assert.success().stdout(predicate::str::is_empty());
+
+    let expected = read_to_string("tests/data/1004916019.txt").unwrap();
+    let expected = if cfg!(windows) {
+        expected.replace('\r', "")
+    } else {
+        expected
+    };
+
+    let actual = read_to_string(filename_str).unwrap();
+    assert_eq!(expected, actual);
+
+    Ok(())
+}
+
+#[test]
 fn pica_print_write_output() -> TestResult {
     let filename = Builder::new().suffix(".txt").tempfile()?;
     let filename_str = filename.path();


### PR DESCRIPTION
This PR fix a bug when a command writes to an existing file. Now, the output file is truncated to 0 length if the file already exists (in non-append mode).

Closes #438 