### PR TITLE
Fix parsing of and-connected filter expressions

### DIFF
--- a/src/matcher/field_matcher.rs
+++ b/src/matcher/field_matcher.rs
@@ -105,13 +105,7 @@ fn parse_field_matcher_subfield(i: &[u8]) -> ParseResult<FieldMatcher> {
                         opt(alt((char('.'), ws(char('$'))))),
                         parse_subfield_list_matcher_singleton,
                     ),
-                    |(prefix, matcher)| {
-                        if prefix.is_none() {
-                            eprintln!("Don't use lazy syntax!");
-                        }
-
-                        matcher
-                    },
+                    |(_prefix, matcher)| matcher,
                 ),
                 preceded(
                     ws(char('{')),

--- a/src/matcher/record_matcher.rs
+++ b/src/matcher/record_matcher.rs
@@ -5,7 +5,7 @@ use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{char, digit1};
 use nom::combinator::{all_consuming, cut, map, map_res, opt};
-use nom::multi::many0;
+use nom::multi::many1;
 use nom::sequence::{preceded, terminated, tuple};
 use nom::Finish;
 
@@ -237,7 +237,7 @@ fn parse_record_matcher_composite_and(i: &[u8]) -> ParseResult<RecordMatcher> {
             ws(parse_record_matcher_not),
             ws(parse_record_matcher_exists),
         )),
-        many0(preceded(
+        many1(preceded(
             ws(tag("&&")),
             alt((
                 ws(parse_record_matcher_group),
@@ -264,7 +264,7 @@ fn parse_record_matcher_composite_or(i: &[u8]) -> ParseResult<RecordMatcher> {
             ws(parse_record_matcher_singleton),
             ws(parse_record_matcher_not),
         )),
-        many0(preceded(
+        many1(preceded(
             ws(tag("||")),
             cut(alt((
                 ws(parse_record_matcher_group),
@@ -314,8 +314,8 @@ fn parse_record_matcher_cardinality(i: &[u8]) -> ParseResult<RecordMatcher> {
 
 pub(crate) fn parse_record_matcher(i: &[u8]) -> ParseResult<RecordMatcher> {
     alt((
-        ws(parse_record_matcher_group),
         ws(parse_record_matcher_composite),
+        ws(parse_record_matcher_group),
         ws(parse_record_matcher_not),
         ws(parse_record_matcher_singleton),
         ws(parse_record_matcher_cardinality),

--- a/tests/pica/filter.rs
+++ b/tests/pica/filter.rs
@@ -142,10 +142,7 @@ fn pica_filter_equal_operator() -> TestResult {
 
     let expected =
         predicate::path::eq_file(Path::new("tests/data/121169502.dat"));
-    assert
-        .success()
-        .stderr("Don\'t use lazy syntax!\n")
-        .stdout(expected);
+    assert.success().stdout(expected);
 
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd
@@ -633,6 +630,19 @@ fn pica_filter_and_connective() -> TestResult {
         .arg("tests/data/121169502.dat")
         .assert();
     assert.success().stdout(predicate::str::is_empty());
+
+    // see https://github.com/deutsche-nationalbibliothek/pica-rs/issues/443
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("filter")
+        .arg("--skip-invalid")
+        .arg("(003@.0 == '121169502') && 002@.0 == 'Tp1'")
+        .arg("tests/data/121169502.dat")
+        .assert();
+
+    let expected =
+        predicate::path::eq_file(Path::new("tests/data/121169502.dat"));
+    assert.success().stdout(expected);
 
     Ok(())
 }


### PR DESCRIPTION
This change fixes parsing of filter expressions, which are connected with a boolean AND operator. The following (vaild) expression failed, due to an error in the parser.

```bash
$ pica filter -s "(003@.0?) && 002@.0 == 'Tp'"
```

Closes #443