### PR TITLE
Add `--or` option to `filter` command

### DIFF
--- a/src/bin/pica/cmds/filter.rs
+++ b/src/bin/pica/cmds/filter.rs
@@ -70,7 +70,15 @@ pub(crate) fn cli() -> Command {
             Arg::new("and")
                 .long("and")
                 .takes_value(true)
-                .multiple_occurrences(true),
+                .multiple_occurrences(true)
+                .conflicts_with("or"),
+        )
+        .arg(
+            Arg::new("or")
+                .long("or")
+                .takes_value(true)
+                .multiple_occurrences(true)
+                .conflicts_with("and")
         )
         .arg(
             Arg::new("allow-list")
@@ -192,8 +200,17 @@ pub(crate) fn run(args: &CliArgs, config: &Config) -> CliResult<()> {
             .collect::<Result<Vec<_>, _>>()?;
 
         for expr in predicates.into_iter() {
-            filter = RecordMatcher::Group(Box::new(filter))
-                & RecordMatcher::Group(Box::new(expr));
+            filter = filter & expr;
+        }
+    } else if args.is_present("or") {
+        let predicates = args
+            .values_of("or")
+            .unwrap()
+            .map(RecordMatcher::new)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        for expr in predicates.into_iter() {
+            filter = filter | expr;
         }
     }
 

--- a/tests/pica/filter.rs
+++ b/tests/pica/filter.rs
@@ -1014,6 +1014,67 @@ fn pica_filter_and_option() -> TestResult {
 }
 
 #[test]
+fn pica_filter_or_option() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("filter")
+        .arg("--skip-invalid")
+        .arg("003@.0 == '121169503'")
+        .arg("--or")
+        .arg("002@.0 == 'Tp1'")
+        .arg("tests/data/121169502.dat")
+        .assert();
+
+    let expected =
+        predicate::path::eq_file(Path::new("tests/data/121169502.dat"));
+    assert.success().stdout(expected);
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("filter")
+        .arg("--skip-invalid")
+        .arg("003@.0 == '121169503'")
+        .arg("--or")
+        .arg("002@.0 == 'Tp2'")
+        .arg("--or")
+        .arg("002@.0 == 'Tp1'")
+        .arg("tests/data/121169502.dat")
+        .assert();
+
+    let expected =
+        predicate::path::eq_file(Path::new("tests/data/121169502.dat"));
+    assert.success().stdout(expected);
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("filter")
+        .arg("--skip-invalid")
+        .arg("003@.0 == '121169502' && 002@.0 == 'Tp2'")
+        .arg("--or")
+        .arg("002@.0 == 'Ts2'")
+        .arg("tests/data/121169502.dat")
+        .assert();
+    assert.success().stdout(predicate::str::is_empty());
+
+    // --or can't be used in combination with --and
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("filter")
+        .arg("--skip-invalid")
+        .arg("003@.0 == '121169503'")
+        .arg("--and")
+        .arg("002@.0 =^ 'Ts'")
+        .arg("--or")
+        .arg("002@.0 == 'Tp1'")
+        .arg("tests/data/121169502.dat")
+        .assert();
+
+    assert.failure().stdout(predicate::str::is_empty());
+
+    Ok(())
+}
+
+#[test]
 fn pica_filter_read_stdin() -> TestResult {
     let input = read_to_string("tests/data/121169502.dat")?;
 


### PR DESCRIPTION
This pull requests adds the `--or` option to the `filter` command. This options is similar to the `--and` option and can be used to split a long filter expression into multiple parts. These parts are connected with the boolean `OR` operator. This can't be used in combination with the `--and` option. This option is especially useful when building the super-set of multiple sub-filters (filter A `or` filter B `or` filter C ...).

## Example

```bash
$ pica filter "002@.0 =^ 'Tp'" --or "002@ =^ 'Ts'" --or "002@.0 =^ 'Tc'" DUMP.dat.gz
```