### PR TITLE
Add `--not` option to `filter` command

### DIFF
--- a/src/matcher/record_matcher.rs
+++ b/src/matcher/record_matcher.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::ops::{BitAnd, BitOr};
+use std::ops::{BitAnd, BitOr, Not};
 
 use nom::branch::alt;
 use nom::bytes::complete::tag;
@@ -163,6 +163,14 @@ impl BitOr for RecordMatcher {
 
     fn bitor(self, rhs: Self) -> Self::Output {
         RecordMatcher::Composite(Box::new(self), BooleanOp::Or, Box::new(rhs))
+    }
+}
+
+impl Not for RecordMatcher {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        RecordMatcher::Not(Box::new(self))
     }
 }
 

--- a/tests/pica/filter.rs
+++ b/tests/pica/filter.rs
@@ -1014,6 +1014,41 @@ fn pica_filter_and_option() -> TestResult {
 }
 
 #[test]
+fn pica_filter_not_option() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("filter")
+        .arg("--skip-invalid")
+        .arg("002@.0 =^ 'Tp'")
+        .arg("--not")
+        .arg("003@.0 == '119232022'")
+        .arg("tests/data/dump.dat.gz")
+        .assert();
+
+    let expected =
+        predicate::path::eq_file(Path::new("tests/data/121169502.dat"));
+    assert.success().stdout(expected);
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("filter")
+        .arg("--skip-invalid")
+        .arg("002@.0 =^ 'Tp'")
+        .arg("--not")
+        .arg("003@.0 == '119232022'")
+        .arg("--not")
+        .arg("003@.0 == '119232023'")
+        .arg("tests/data/dump.dat.gz")
+        .assert();
+
+    let expected =
+        predicate::path::eq_file(Path::new("tests/data/121169502.dat"));
+    assert.success().stdout(expected);
+
+    Ok(())
+}
+
+#[test]
 fn pica_filter_or_option() -> TestResult {
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd
@@ -1063,6 +1098,21 @@ fn pica_filter_or_option() -> TestResult {
         .arg("--skip-invalid")
         .arg("003@.0 == '121169503'")
         .arg("--and")
+        .arg("002@.0 =^ 'Ts'")
+        .arg("--or")
+        .arg("002@.0 == 'Tp1'")
+        .arg("tests/data/121169502.dat")
+        .assert();
+
+    assert.failure().stdout(predicate::str::is_empty());
+
+    // --or can't be used in combination with --not
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("filter")
+        .arg("--skip-invalid")
+        .arg("003@.0 == '121169503'")
+        .arg("--not")
         .arg("002@.0 =^ 'Ts'")
         .arg("--or")
         .arg("002@.0 == 'Tp1'")


### PR DESCRIPTION
This pull request adds the `--not` option to the `filter` command. This option is similar to `--and` and can be used to split a long filter expression into multiple parts. These parts are connected with the boolean `AND` operator and the expression of the not-part is negated. This can't be used in combination with the `--or` option.
## Example

```bash
$ pica filter "002@.0 =^ 'T'" --and "002@ =$ '1'" --not "002@.0 == 'Tp1'" DUMP.dat.gz
```