### PR TITLE
Add `--tee` option to `filter` command

### DIFF
--- a/tests/pica/filter.rs
+++ b/tests/pica/filter.rs
@@ -1569,6 +1569,31 @@ fn pica_filter_expression_file() -> TestResult {
 }
 
 #[test]
+fn pica_filter_tee_option() -> TestResult {
+    let filename = Builder::new().suffix(".dat").tempfile()?;
+    let filename_str = filename.path();
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("filter")
+        .arg("--tee")
+        .arg(filename_str)
+        .arg("003@.0 == '1004916019'")
+        .arg("tests/data/1004916019.dat")
+        .assert();
+
+    let expected =
+        predicate::path::eq_file(Path::new("tests/data/1004916019.dat"));
+    assert.success().stdout(expected);
+
+    let expected =
+        predicate::path::eq_file(Path::new("tests/data/1004916019.dat"));
+    assert!(expected.eval(Path::new(filename_str)));
+
+    Ok(())
+}
+
+#[test]
 fn pica_filter_invalid_filter() -> TestResult {
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd


### PR DESCRIPTION
This change adds the `--tee` option to the `filter` command. This option acts like the linux `tee` command. If this option is set, the output of the `filter` command will be written to a file (`tee`'s value) and to the standard output (`stdout`). This feature is usefull when the output is needed by a next command (separate call) *and* the output is processed by a other command (in a pipeline).

The option `--tee` cannot be used in combination with `--output`.

## Example

```bash
$ pica filter -s --tee gnd.dat "002@.0 =^ 'T'" | pica filter "002@.0 =^ 'Ts'" -o gnd_subject_terms.dat
```