### PR TITLE
Add `--append` option to `filter` command

### DIFF
--- a/src/bin/pica/cmds/filter.rs
+++ b/src/bin/pica/cmds/filter.rs
@@ -61,6 +61,11 @@ pub(crate) fn cli() -> Command {
                 .help("The minimum score for string similarity comparisons (range from 0.0..1.0).")
         )
         .arg(
+            Arg::new("append")
+                .long("--append")
+                .help("Append to the given <file>, do not overwrite.")
+       )
+        .arg(
             Arg::new("reduce")
                 .long("reduce")
                 .help("Reduce the record to the following fields.")
@@ -147,6 +152,7 @@ pub(crate) fn run(args: &CliArgs, config: &Config) -> CliResult<()> {
     let skip_invalid = skip_invalid_flag!(args, config.filter, config.global);
     let gzip_compression = gzip_flag!(args, config.filter);
     let ignore_case = args.is_present("ignore-case");
+    let append = args.is_present("append");
 
     let mut allow_list = FilterList::default();
     let mut deny_list = FilterList::default();
@@ -162,12 +168,14 @@ pub(crate) fn run(args: &CliArgs, config: &Config) -> CliResult<()> {
 
     let mut writer: Box<dyn PicaWriter> = WriterBuilder::new()
         .gzip(gzip_compression)
+        .append(append)
         .from_path_or_stdout(args.value_of("output"))?;
 
     let mut tee_writer = match args.value_of("tee") {
         Some(path) => Some(
             WriterBuilder::new()
                 .gzip(gzip_compression)
+                .append(append)
                 .from_path(path)?,
         ),
         None => None,


### PR DESCRIPTION
This change adds the `--append` option to the `filter` command. If this flag is set, the output will be appended to the file (if exists), otherwise the file will be crated. The flag is disabled by default and must be set explicitly. The behaviour of the `--output` value as well as the `--tee` value is affected by this flag.

The flag has no effect when writing to standard output (`stdout`).

## Example

```bash
$ pica filter "002@.0 == 'Ts1'" DUMP.dat.gz -o gnd.dat
$ pica filter --append "002@.0 == 'Tp1'" DUMP.dat.gz -o gnd.dat
$ pica filter --append "002@.0 == 'Tpz'" DUMP.dat.gz -o gnd.dat
```