### PR TITLE
Add short option for allow- and deny-lists

### DIFF
--- a/src/bin/pica/cmds/filter.rs
+++ b/src/bin/pica/cmds/filter.rs
@@ -93,12 +93,14 @@ pub(crate) fn cli() -> Command {
         .arg(
             Arg::new("allow-list")
                 .long("--allow-list")
+                .short('A')
                 .takes_value(true)
                 .multiple_occurrences(true)
         )
         .arg(
             Arg::new("deny-list")
                 .long("--deny-list")
+                .short('D')
                 .takes_value(true)
                 .multiple_occurrences(true)
         )

--- a/tests/pica/filter.rs
+++ b/tests/pica/filter.rs
@@ -2112,5 +2112,23 @@ fn pica_filter_allow_deny_listing() -> TestResult {
     ));
     assert.success().stdout(expected);
 
+    // short options
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("filter")
+        .arg("--skip-invalid")
+        .arg("-A")
+        .arg("tests/data/allow_list.csv")
+        .arg("-D")
+        .arg("tests/data/deny_list.csv")
+        .arg("003@.0?")
+        .arg("tests/data/dump.dat.gz")
+        .assert();
+
+    let expected = predicate::path::eq_file(Path::new(
+        "tests/data/1004916019.dat",
+    ));
+    assert.success().stdout(expected);
+
     Ok(())
 }


### PR DESCRIPTION
The change introduce the short version of the `--allow-list` (`-A`) and `--deny-list` (`-D`) options of the `filter` command. Now, the following commands are equivalent:

```bash
$ pica filter --allow-list ALLOW.csv --deny-list DENY.csv "003@?" DUMP.dat.gz
$ pica filter -A ALLOW.csv -D DENY.csv "003@?" DUMP.dat.gz
```