### PR TITLE
Allow filter expresions in `select` command

### DIFF
--- a/src/bin/pica/cmds/select.rs
+++ b/src/bin/pica/cmds/select.rs
@@ -5,6 +5,7 @@ use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
 
 use clap::Arg;
+use pica::matcher::{MatcherFlags, RecordMatcher};
 use pica::{Outcome, ReaderBuilder, Selectors};
 use serde::{Deserialize, Serialize};
 
@@ -66,6 +67,12 @@ pub(crate) fn cli() -> Command {
                 .help("Comma-separated list of column names."),
         )
         .arg(
+            Arg::new("filter")
+                .long("where")
+                .help("A expression used for filtering records.")
+                .takes_value(true),
+        )
+        .arg(
             Arg::new("output")
                 .short('o')
                 .long("--output")
@@ -114,8 +121,27 @@ pub(crate) fn run(args: &CliArgs, config: &Config) -> CliResult<()> {
         writer.write_record(header.split(',').map(|s| s.trim()))?;
     }
 
+    let flags = MatcherFlags::default();
+    let filter = match args.value_of("filter") {
+        Some(filter_str) => match RecordMatcher::new(&filter_str) {
+            Ok(f) => f,
+            _ => {
+                return Err(CliError::Other(format!(
+                    "invalid filter: \"{}\"",
+                    filter_str
+                )))
+            }
+        },
+        None => RecordMatcher::True,
+    };
+
     for result in reader.records() {
         let record = result?;
+
+        if !filter.is_match(&record, &flags) {
+            continue;
+        }
+
         let outcome = selectors
             .iter()
             .map(|selector| record.select(selector, ignore_case))

--- a/src/bin/pica/cmds/select.rs
+++ b/src/bin/pica/cmds/select.rs
@@ -123,7 +123,7 @@ pub(crate) fn run(args: &CliArgs, config: &Config) -> CliResult<()> {
 
     let flags = MatcherFlags::default();
     let filter = match args.value_of("filter") {
-        Some(filter_str) => match RecordMatcher::new(&filter_str) {
+        Some(filter_str) => match RecordMatcher::new(filter_str) {
             Ok(f) => f,
             _ => {
                 return Err(CliError::Other(format!(

--- a/tests/pica/select.rs
+++ b/tests/pica/select.rs
@@ -451,6 +451,28 @@ fn pica_select_translit() -> TestResult {
 
     Ok(())
 }
+#[test]
+fn pica_select_where() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("select")
+        .arg("--skip-invalid")
+        .arg("003@.0")
+        .arg("--where")
+        .arg("003@.0 =^ '0'")
+        .arg("tests/data/dump.dat.gz")
+        .assert();
+
+    assert.success().stderr(predicate::str::is_empty()).stdout(
+        r#"000008672
+000016586
+000016756
+000009229
+"#,
+    );
+
+    Ok(())
+}
 
 #[test]
 fn pica_select_skip_invalid() -> TestResult {


### PR DESCRIPTION
With this change it is now possible to filter records in a `select` command. Until now, it was necessary to use a combination of the `filter` and  `select` command in order to get data from a subset of records. Now, the `select` command provides the `--where` option, which accepts a pica filter expression.

The following comamnds are equivalent:

```bash
$ pica filter -s "003@.0 =^ '0'" DUMP.dat.gz | pica select "003@.0" -o idn.csv
$ pica select -s "003@.0" --where "003@.0 =^ '0'" DUMP.dat.gz  -o idn.csv
```