### PR TITLE
Add `--append` option to `select` command

### DIFF
--- a/tests/pica/select.rs
+++ b/tests/pica/select.rs
@@ -409,6 +409,66 @@ fn pica_select_write_output() -> TestResult {
 }
 
 #[test]
+fn pica_select_append() -> TestResult {
+    let filename = Builder::new().suffix(".csv").tempfile()?;
+    let filename_str = filename.path();
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("select")
+        .arg("-o")
+        .arg(filename_str)
+        .arg("003@.0, 002@.0")
+        .arg("tests/data/119232022.dat.gz")
+        .assert();
+    assert.success().stdout(predicate::str::is_empty());
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("select")
+        .arg("--append")
+        .arg("-o")
+        .arg(filename_str)
+        .arg("003@.0, 002@.0")
+        .arg("tests/data/1004916019.dat.gz")
+        .assert();
+    assert.success().stdout(predicate::str::is_empty());
+
+    assert_eq!(
+        read_to_string(filename).unwrap(),
+        "119232022,Tp1\n1004916019,Ts1\n"
+    );
+
+    // cross check
+    let filename = Builder::new().suffix(".csv").tempfile()?;
+    let filename_str = filename.path();
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("select")
+        .arg("-o")
+        .arg(filename_str)
+        .arg("003@.0, 002@.0")
+        .arg("tests/data/119232022.dat.gz")
+        .assert();
+    assert.success().stdout(predicate::str::is_empty());
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("select")
+        .arg("-o")
+        .arg(filename_str)
+        .arg("003@.0, 002@.0")
+        .arg("tests/data/1004916019.dat.gz")
+        .assert();
+    assert.success().stdout(predicate::str::is_empty());
+
+    assert_eq!(read_to_string(filename).unwrap(), "1004916019,Ts1\n");
+
+    Ok(())
+}
+
+#[test]
 fn pica_select_translit() -> TestResult {
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd


### PR DESCRIPTION
This change adds the `--append` option to the `select` command. If this flag is set, the output will be appended to the file (if exists), otherwise the file will be crated. The flag is disabled by default and must be set explicitly.

The flag has no effect when writing to standard output (`stdout`).

## Example

```bash
$ pica select "003@.0, 002@.0" tests/data/1004916019.dat.gz -o out.csv
$ pica select "003@.0, 002@.0" tests/data/119232022.dat.gz --append -o out.csv
$ cat out.csv
1004916019,Ts1
119232022,Tp1
```