### PR TITLE
Improve `invalid` performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ toml = "0.5"
 unicode-normalization = "0.1"
 xml-rs = "0.8"
 
+pica-record = { version = "0.1", path = "pica-record" }
+
 [dev-dependencies]
 assert_cmd = "2.0"
 predicates = "2.1"


### PR DESCRIPTION
This change improves the performance of the `invalid` command. The performance gain is achieved by using the new `pica-record` crate, which avoids as much unnecessary memory allocations as possible.

## Benchmark

The benchmark uses an uncompressed dump of 37,238,584 records (47GB) with 15 invalid records. The measurements were made using hypefine with the following parameters:

```bash
$ hyperfine --prepare 'sync; echo 3 | sudo tee /proc/sys/vm/drop_caches' --export-markdown invalid.md \
    -L binary ${CARGO_BIN}/pica,${PROJECT_BIN}/pica '{binary} invalid DUMP.dat -o invalid.dat'
```

### Rust Stable

```bash
$ rustc -V
rustc 1.64.0 (a55dd71d5 2022-09-19)
```

| Revision | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `main` (`3564264`) | 797.436 ± 1.703 | 795.114 | 800.616 | 2.92 ± 0.01 |
| `HEAD` (`218e4c9`) | 273.148 ± 0.957 | 271.643 | 274.689 | 1.00 |

### Rust Nightly

```bash
$ rustc -V
rustc 1.66.0-nightly (c0983a9aa 2022-10-12)
```

| Revision | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `main` (`3564264`) | 759.819 ± 1.248 | 757.376 | 761.641 | 2.86 ± 0.01 |
| `HEAD` (`218e4c9`) | 265.270 ± 0.853 | 264.008 | 266.623 | 1.00 |