### PR TITLE
Use `first()` instead of `iter().next()`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --workspace -- -D warnings -D rust-2021-compatibility -W unreachable-pub
 
   udeps:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}

--- a/pica-path/CHANGELOG.md
+++ b/pica-path/CHANGELOG.md
@@ -11,3 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - #550 Add initial `pica-path` crate
 - #551 Implement `Deserialize` for `Path`
+
+### Fixed
+
+- #555 Use `first()` instead of `iter().next()`

--- a/pica-path/src/lib.rs
+++ b/pica-path/src/lib.rs
@@ -129,7 +129,7 @@ pub trait PathExt<T: AsRef<[u8]>> {
     /// }
     /// ```
     fn idn(&self) -> Option<&T> {
-        self.path(&Path::new("003@.0")).iter().next().copied()
+        self.path(&Path::new("003@.0")).first().copied()
     }
 }
 


### PR DESCRIPTION
Fix clippy warning:

```bash
error: using `.iter().next()` on an array
Error:    --> pica-path/src/lib.rs:132:9
    |
132 |         self.path(&Path::new("003@.0")).iter().next().copied()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try calling: `self.path(&Path::new("003@.0")).first()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_next_slice
    = note: `-D clippy::iter-next-slice` implied by `-D warnings`

error: could not compile `pica-path` due to previous error
Error: warning: build failed, waiting for other jobs to finish...
Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
```