### PR TITLE
Include CLI completion files in packages

### DIFF
--- a/.github/actions-rs/package.yaml
+++ b/.github/actions-rs/package.yaml
@@ -8,3 +8,15 @@ files:
     file: pica
     mode: "0755"
     user: "root"
+  "/usr/share/bash-completion/completions/pica.bash":
+    file: pica.bash
+    mode: "0755"
+    user: "root"
+  "/usr/share/zsh/vendor-completions/_pica":
+    file: pica.zsh
+    mode: "0755"
+    user: "root"
+  "/usr/share/fish/vendor_completions.d/pica.fish":
+    file: pica.fish
+    mode: "0755"
+    user: "root"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,9 @@ jobs:
           mkdir "$staging"
           cp README.md LICENSE UNLICENSE "$staging/"
           cp "target/release/pica" "$staging/"
+          ./target/release/pica completions bash > "$stating/pica.bash"
+          ./target/release/pica completions zsh > "$stating/pica.zsh"
+          ./target/release/pica completions fish > "$stating/pica.fish"
           # cp "target/release/pica-lint" "$staging/"
           tar cfvz "$staging.tar.gz" "$staging/"
           echo "filename=$staging.tar.gz" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This should work to fix #574 but I have not tested generation of packages with this GitHub workflow.