### PR TITLE
Add common option --limit/-n

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Examples:
 $ pica slice --skip-invalid --start 1 --end 4 -o slice.dat DUMP.dat
 
 # get 10 records from position 10
-$ pica slice --skip-invalid --start 10 --length 10 -o slice.dat DUMP.dat
+$ pica slice --skip-invalid --start 10 --limit 10 -o slice.dat DUMP.dat
 ```
 
 ### Split

--- a/src/bin/pica/commands/cat.rs
+++ b/src/bin/pica/commands/cat.rs
@@ -26,6 +26,10 @@ pub(crate) struct Cat {
     #[arg(short, long)]
     skip_invalid: bool,
 
+    /// Limit the result to first <n> records
+    #[arg(long, short = 'n', value_name = "n", default_value = "0")]
+    limit: usize,
+
     /// Append to the given file, do not overwrite
     #[arg(long)]
     append: bool,
@@ -73,7 +77,9 @@ impl Cat {
             None => None,
         };
 
-        for filename in self.filenames {
+        let mut count = 0;
+
+        'reading: for filename in self.filenames {
             let mut reader =
                 ReaderBuilder::new().from_path(filename)?;
 
@@ -90,6 +96,10 @@ impl Cat {
                         writer.write_byte_record(&record)?;
                         if let Some(ref mut writer) = tee_writer {
                             writer.write_byte_record(&record)?;
+                        }
+                        count += 1;
+                        if self.limit > 0 && count >= self.limit {
+                            break 'reading;
                         }
                     }
                 }

--- a/src/bin/pica/commands/filter.rs
+++ b/src/bin/pica/commands/filter.rs
@@ -69,7 +69,7 @@ pub(crate) struct Filter {
     deny_list: Vec<PathBuf>,
 
     /// Limit the result to first <n> records
-    #[arg(long, short, value_name = "n", default_value = "0")]
+    #[arg(long, short = 'n', value_name = "n", default_value = "0")]
     limit: usize,
 
     /// Connects the filter with additional expressions using the

--- a/src/bin/pica/commands/json.rs
+++ b/src/bin/pica/commands/json.rs
@@ -22,6 +22,10 @@ pub(crate) struct Json {
     #[arg(short, long)]
     skip_invalid: bool,
 
+    /// Limit the result to first <n> records
+    #[arg(long, short = 'n', value_name = "n", default_value = "0")]
+    limit: usize,
+
     /// Transliterate output into the selected normalform <NF>
     /// (possible values: "nfd", "nfkd", "nfc" and "nfkc")
     #[arg(long,
@@ -53,8 +57,10 @@ impl Json {
         writer.write_all(b"[")?;
 
         for filename in self.filenames {
-            let builder =
-                ReaderBuilder::new().skip_invalid(skip_invalid);
+            let builder = ReaderBuilder::new()
+                .skip_invalid(skip_invalid)
+                .limit(self.limit);
+
             let mut reader: Reader<Box<dyn Read>> = match filename
                 .to_str()
             {

--- a/src/bin/pica/commands/print.rs
+++ b/src/bin/pica/commands/print.rs
@@ -77,7 +77,7 @@ pub(crate) struct Print {
     skip_invalid: bool,
 
     /// Limit the result to first <n> records
-    #[arg(long, short, value_name = "n", default_value = "0")]
+    #[arg(long, short = 'n', value_name = "n", default_value = "0")]
     limit: usize,
 
     /// Transliterate output into the selected normalform <NF>

--- a/src/bin/pica/commands/select.rs
+++ b/src/bin/pica/commands/select.rs
@@ -27,6 +27,10 @@ pub(crate) struct Select {
     #[arg(short, long)]
     skip_invalid: bool,
 
+    /// Limit selection to first <n> records
+    #[arg(long, short = 'n', value_name = "n", default_value = "0")]
+    limit: usize,
+
     /// Disallow empty columns
     #[arg(long)]
     no_empty_columns: bool,
@@ -135,8 +139,10 @@ impl Select {
         };
 
         for filename in self.filenames {
-            let builder =
-                ReaderBuilder::new().skip_invalid(skip_invalid);
+            let builder = ReaderBuilder::new()
+                .skip_invalid(skip_invalid)
+                .limit(self.limit);
+
             let mut reader: Reader<Box<dyn Read>> = match filename
                 .to_str()
             {

--- a/src/bin/pica/commands/slice.rs
+++ b/src/bin/pica/commands/slice.rs
@@ -29,9 +29,9 @@ pub(crate) struct Slice {
     #[arg(long, default_value = "0")]
     end: usize,
 
-    /// The length of the slice
-    #[arg(long, default_value = "0", conflicts_with = "end")]
-    length: usize,
+    /// The length of the slice (stop after <n> records)
+    #[arg(long, short, value_name = "n", default_value = "0", conflicts_with = "end")]
+    limit: usize,
 
     /// Compress output in gzip format
     #[arg(long, short)]
@@ -61,8 +61,8 @@ impl Slice {
 
         let mut range = if self.end > 0 {
             self.start..self.end
-        } else if self.length > 0 {
-            self.start..(self.start + self.length)
+        } else if self.limit > 0 {
+            self.start..(self.start + self.limit)
         } else {
             self.start..::std::usize::MAX
         };
@@ -94,7 +94,7 @@ impl Slice {
                         return Err(CliError::from(e))
                     }
                     _ => {
-                        if self.length > 0
+                        if self.limit > 0
                             && range.end < std::usize::MAX
                         {
                             range.end += 1;

--- a/src/bin/pica/commands/slice.rs
+++ b/src/bin/pica/commands/slice.rs
@@ -30,7 +30,7 @@ pub(crate) struct Slice {
     end: usize,
 
     /// The length of the slice (stop after <n> records)
-    #[arg(long, short, value_name = "n", default_value = "0", conflicts_with = "end")]
+    #[arg(long, short = 'n', value_name = "n", default_value = "0", conflicts_with = "end")]
     limit: usize,
 
     /// Compress output in gzip format

--- a/src/bin/pica/commands/xml.rs
+++ b/src/bin/pica/commands/xml.rs
@@ -26,6 +26,10 @@ pub(crate) struct Xml {
     #[arg(long, short)]
     skip_invalid: bool,
 
+    /// Limit the result to first <n> records
+    #[arg(long, short = 'n', value_name = "n", default_value = "0")]
+    limit: usize,
+
     /// Transliterate output into the selected normalform <NF>
     /// (possible values: "nfd", "nfkd", "nfc" and "nfkc")
     #[arg(long,
@@ -74,8 +78,9 @@ impl Xml {
         )?;
 
         for filename in self.filenames {
-            let builder =
-                ReaderBuilder::new().skip_invalid(skip_invalid);
+            let builder = ReaderBuilder::new()
+                .skip_invalid(skip_invalid)
+                .limit(self.limit);
             let mut reader: Reader<Box<dyn Read>> = match filename
                 .to_str()
             {

--- a/tests/pica/slice.rs
+++ b/tests/pica/slice.rs
@@ -446,7 +446,7 @@ fn pica_slice_length() -> TestResult {
     let assert = cmd
         .arg("slice")
         .arg("--skip-invalid")
-        .arg("--length")
+        .arg("--limit")
         .arg("1")
         .arg("tests/data/dump.dat.gz")
         .assert();
@@ -461,7 +461,7 @@ fn pica_slice_length() -> TestResult {
     let assert = cmd
         .arg("slice")
         .arg("--skip-invalid")
-        .arg("--length")
+        .arg("--limit")
         .arg("2")
         .arg("tests/data/dump.dat.gz")
         .assert();
@@ -482,7 +482,7 @@ fn pica_slice_length() -> TestResult {
     let assert = cmd
         .arg("slice")
         .arg("--skip-invalid")
-        .arg("--length")
+        .arg("--limit")
         .arg("100")
         .arg("tests/data/dump.dat.gz")
         .assert();
@@ -515,7 +515,7 @@ fn pica_slice_length() -> TestResult {
         .arg("--skip-invalid")
         .arg("--start")
         .arg("1")
-        .arg("--length")
+        .arg("--limit")
         .arg("1")
         .arg("tests/data/dump.dat.gz")
         .assert();
@@ -526,12 +526,12 @@ fn pica_slice_length() -> TestResult {
         .stderr(predicate::str::is_empty())
         .stdout(expected);
 
-    // invalid length option
+    // invalid limit option
     let mut cmd = Command::cargo_bin("pica")?;
     let assert = cmd
         .arg("slice")
         .arg("--skip-invalid")
-        .arg("--length")
+        .arg("--limit")
         .arg("abc")
         .arg("tests/data/dump.dat.gz")
         .assert();


### PR DESCRIPTION
All commands should have same option `--limit` with short `-n` as used from command `head` to run a command with a fixed number records. I just started to dig into Rust and this pull request does not cover all commands yet, so this is just for code review. 