### PR TITLE
Support of double quoted string literals

### DIFF
--- a/pica-matcher/CHANGELOG.md
+++ b/pica-matcher/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * #611 Allow negation of a field matcher in curly bracket notation
+* #612 Support of double quoted string literals
 
 ## v0.1.0
 

--- a/tests/snapshot/filter/0300-filter-double-quotes.stdin
+++ b/tests/snapshot/filter/0300-filter-double-quotes.stdin
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/tests/snapshot/filter/0300-filter-double-quotes.stdout
+++ b/tests/snapshot/filter/0300-filter-double-quotes.stdout
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/tests/snapshot/filter/0300-filter-double-quotes.toml
+++ b/tests/snapshot/filter/0300-filter-double-quotes.toml
@@ -1,0 +1,4 @@
+bin.name = "pica"
+args = "filter '003@.0 == \"040011569\" && !012A.0?'"
+status = "success"
+stderr = ""


### PR DESCRIPTION
This PR adds support of double quoted string literals in a matcher expressions. The following two commands are equivalent:

```bash
$ pica filter '003@.0? && !041A.0?' DUMP.dat
$ pica filter "003@.0? && \!041A.0?" DUMP.dat
```