### PR TITLE
Allow single-line comments 

### DIFF
--- a/pica-matcher/src/field_matcher.rs
+++ b/pica-matcher/src/field_matcher.rs
@@ -13,7 +13,7 @@ use pica_record::parser::ParseResult;
 use pica_record::Field;
 
 use crate::common::{
-    parse_relational_op_usize, ws, BooleanOp, RelationalOp,
+    comment, parse_relational_op_usize, ws, BooleanOp, RelationalOp,
 };
 use crate::occurrence_matcher::{
     parse_occurrence_matcher, OccurrenceMatcher,
@@ -579,21 +579,21 @@ fn parse_field_matcher_not(i: &[u8]) -> ParseResult<FieldMatcher> {
 fn parse_field_matcher_and(i: &[u8]) -> ParseResult<FieldMatcher> {
     let (i, (first, remainder)) = tuple((
         alt((
-            ws(parse_field_matcher_group),
-            ws(parse_field_matcher_cardinality),
-            ws(parse_field_matcher_singleton),
-            ws(parse_field_matcher_not),
-            ws(parse_field_matcher_exists),
+            comment(ws(parse_field_matcher_group)),
+            comment(ws(parse_field_matcher_cardinality)),
+            comment(ws(parse_field_matcher_singleton)),
+            comment(ws(parse_field_matcher_not)),
+            comment(ws(parse_field_matcher_exists)),
         )),
         many1(preceded(
-            ws(tag("&&")),
-            alt((
-                ws(parse_field_matcher_group),
-                ws(parse_field_matcher_cardinality),
-                ws(parse_field_matcher_singleton),
-                ws(parse_field_matcher_not),
-                ws(parse_field_matcher_exists),
-            )),
+            comment(ws(tag("&&"))),
+            cut(alt((
+                comment(ws(parse_field_matcher_group)),
+                comment(ws(parse_field_matcher_cardinality)),
+                comment(ws(parse_field_matcher_singleton)),
+                comment(ws(parse_field_matcher_not)),
+                comment(ws(parse_field_matcher_exists)),
+            ))),
         )),
     ))(i)?;
 
@@ -606,20 +606,20 @@ fn parse_field_matcher_and(i: &[u8]) -> ParseResult<FieldMatcher> {
 fn parse_field_matcher_or(i: &[u8]) -> ParseResult<FieldMatcher> {
     let (i, (first, remainder)) = tuple((
         alt((
-            ws(parse_field_matcher_group),
-            ws(parse_field_matcher_and),
-            ws(parse_field_matcher_cardinality),
-            ws(parse_field_matcher_singleton),
-            ws(parse_field_matcher_exists),
+            comment(ws(parse_field_matcher_group)),
+            comment(ws(parse_field_matcher_and)),
+            comment(ws(parse_field_matcher_cardinality)),
+            comment(ws(parse_field_matcher_singleton)),
+            comment(ws(parse_field_matcher_exists)),
         )),
         many1(preceded(
-            ws(tag("||")),
+            comment(ws(tag("||"))),
             cut(alt((
-                ws(parse_field_matcher_group),
-                ws(parse_field_matcher_and),
-                ws(parse_field_matcher_cardinality),
-                ws(parse_field_matcher_singleton),
-                ws(parse_field_matcher_exists),
+                comment(ws(parse_field_matcher_group)),
+                comment(ws(parse_field_matcher_and)),
+                comment(ws(parse_field_matcher_cardinality)),
+                comment(ws(parse_field_matcher_singleton)),
+                comment(ws(parse_field_matcher_exists)),
             ))),
         )),
     ))(i)?;

--- a/pica-matcher/src/subfield_matcher.rs
+++ b/pica-matcher/src/subfield_matcher.rs
@@ -19,8 +19,8 @@ use regex::Regex;
 use strsim::normalized_levenshtein;
 
 use crate::common::{
-    parse_relational_op_str, parse_relational_op_usize, parse_string,
-    ws, BooleanOp, RelationalOp,
+    comment, parse_relational_op_str, parse_relational_op_usize,
+    parse_string, ws, BooleanOp, RelationalOp,
 };
 use crate::{MatcherOptions, ParseMatcherError};
 
@@ -735,18 +735,18 @@ fn parse_group_matcher(i: &[u8]) -> ParseResult<SubfieldMatcher> {
 fn parse_or_matcher(i: &[u8]) -> ParseResult<SubfieldMatcher> {
     let (i, (first, remainder)) = tuple((
         alt((
-            ws(parse_group_matcher),
-            ws(parse_and_matcher),
-            ws(parse_subfield_singleton_matcher),
-            ws(parse_not_matcher),
+            comment(ws(parse_group_matcher)),
+            comment(ws(parse_and_matcher)),
+            comment(ws(parse_subfield_singleton_matcher)),
+            comment(ws(parse_not_matcher)),
         )),
         many1(preceded(
-            ws(tag("||")),
+            comment(ws(tag("||"))),
             cut(alt((
-                ws(parse_group_matcher),
-                ws(parse_and_matcher),
-                ws(parse_subfield_singleton_matcher),
-                ws(parse_not_matcher),
+                comment(ws(parse_group_matcher)),
+                comment(ws(parse_and_matcher)),
+                comment(ws(parse_subfield_singleton_matcher)),
+                comment(ws(parse_not_matcher)),
             ))),
         )),
     ))(i)?;
@@ -760,22 +760,22 @@ fn parse_or_matcher(i: &[u8]) -> ParseResult<SubfieldMatcher> {
 fn parse_and_matcher(i: &[u8]) -> ParseResult<SubfieldMatcher> {
     let (i, (first, remainder)) = tuple((
         alt((
-            ws(parse_group_matcher),
-            map(
+            comment(ws(parse_group_matcher)),
+            comment(map(
                 ws(parse_singleton_matcher),
                 SubfieldMatcher::Singleton,
-            ),
-            ws(parse_not_matcher),
+            )),
+            comment(ws(parse_not_matcher)),
         )),
         many1(preceded(
-            ws(tag("&&")),
+            comment(ws(tag("&&"))),
             alt((
-                ws(parse_group_matcher),
-                map(
+                comment(ws(parse_group_matcher)),
+                comment(map(
                     ws(parse_singleton_matcher),
                     SubfieldMatcher::Singleton,
-                ),
-                ws(parse_not_matcher),
+                )),
+                comment(ws(parse_not_matcher)),
             )),
         )),
     ))(i)?;


### PR DESCRIPTION
### Examples

```bash
$ cat filter.txt
041P{
    a == 'Algebra' && // Sachbegriff
    2 == 'lcsh'       // Code der Quelle
}

$ pica filter -f filter.txt "003@.0?" tests/snapshot/data/algebra.dat | pica count --records
1
```

```bash
$ cat filter.txt
041P.a == 'Algebra' ||  // Sachbegriff
041P.2 == 'lcsh'       // Code der Quelle

$ pica filter -f filter.txt "003@.0?" tests/snapshot/data/algebra.dat | pica count --records
1
```

Closes #457