### PR TITLE
Fix `limit` in `filter` command

### DIFF
--- a/src/bin/pica/commands/filter.rs
+++ b/src/bin/pica/commands/filter.rs
@@ -222,7 +222,7 @@ impl Filter {
             .strsim_threshold(self.strsim_threshold as f64 / 100.0)
             .case_ignore(self.ignore_case);
 
-        for filename in self.filenames {
+        'outer: for filename in self.filenames {
             let mut reader =
                 ReaderBuilder::new().from_path(filename)?;
 
@@ -294,7 +294,7 @@ impl Filter {
                         }
 
                         if self.limit > 0 && count >= self.limit {
-                            break;
+                            break 'outer;
                         }
                     }
                 }

--- a/tests/snapshot/filter/0207-filter-limit.toml
+++ b/tests/snapshot/filter/0207-filter-limit.toml
@@ -1,4 +1,4 @@
 bin.name = "pica"
-args = "filter -s -l 2 \"002@.0 =^ 'Ts'\" dump.dat.gz -o out.dat.gz"
+args = "filter -s -l 2 \"002@.0 =^ 'Ts'\" dump.dat.gz dump.dat.gz -o out.dat.gz"
 status = "success"
 stderr = ""


### PR DESCRIPTION
This PR fixes a bug in `filter` command using the `limit` option. The bug only exists if more than one file is processed and the limit is less than the number of valid records (of all files). If the limit was reached the code stopped processing the current file, but continued with the remaining files. For each remaining file, up to one (valid) record was written to the output.