### PR TITLE
Print more helpful error message on `ParsePicaError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #641 Stabilize `sample` command
 * #642 Add `--squash` and `--merge` option
 
+### Changed
+
+* #643 Print more helpful error message on `ParsePicaError` 
+
 ### Removed
 
 * #639 Remove `xml` command

--- a/pica-record/src/io/mod.rs
+++ b/pica-record/src/io/mod.rs
@@ -23,8 +23,8 @@ pub use writer::{
 /// [BufReader](std::io::BufReader).
 #[derive(Error, Debug)]
 pub enum ReadPicaError {
-    #[error("parse error")]
-    Parse(#[from] ParsePicaError),
+    #[error("parse error: {msg:?}")]
+    Parse { msg: String, err: ParsePicaError },
 
     #[error("io error")]
     Io(#[from] io::Error),
@@ -34,7 +34,13 @@ impl ReadPicaError {
     /// Returns true, if the underlying error was caused by parsing an
     /// invalid record.
     pub fn is_invalid_record(&self) -> bool {
-        matches!(self, Self::Parse(ParsePicaError::InvalidRecord(_)))
+        matches!(
+            self,
+            Self::Parse {
+                msg: _,
+                err: ParsePicaError::InvalidRecord(_)
+            }
+        )
     }
 }
 

--- a/pica-record/src/io/mod.rs
+++ b/pica-record/src/io/mod.rs
@@ -44,6 +44,15 @@ impl ReadPicaError {
     }
 }
 
+impl From<ParsePicaError> for ReadPicaError {
+    fn from(err: ParsePicaError) -> Self {
+        Self::Parse {
+            msg: "invalid record".into(),
+            err,
+        }
+    }
+}
+
 /// An extension of [BufRead](`std::io::BufRead`) which provides a
 /// convenience API for reading [ByteRecord](`crate::ByteRecord`)s.
 pub trait BufReadExt: io::BufRead {

--- a/pica-record/src/io/reader.rs
+++ b/pica-record/src/io/reader.rs
@@ -34,7 +34,7 @@ impl ReaderBuilder {
     ///     let data =
     ///         Cursor::new(b"003@ \x1f0abc\x1e\n003@ \x1f0def\x1e\n");
     ///     let mut reader =
-    ///         ReaderBuilder::new().limit(1).from_reader(data);
+    ///         ReaderBuilder::new().limit(1).from_reader(data, None);
     ///
     ///     let mut count = 0;
     ///     while let Some(result) = reader.next() {
@@ -60,7 +60,7 @@ impl ReaderBuilder {
     /// fn example() -> anyhow::Result<()> {
     ///     let data =
     ///         Cursor::new(b"003@ \x1f0abc\x1e\n003@ \x1f0def\x1e\n");
-    ///     let mut reader = ReaderBuilder::new().from_reader(data);
+    ///     let mut reader = ReaderBuilder::new().from_reader(data, None);
     ///
     ///     let mut count = 0;
     ///     while let Some(result) = reader.next() {

--- a/pica-record/src/io/reader.rs
+++ b/pica-record/src/io/reader.rs
@@ -72,8 +72,12 @@ impl ReaderBuilder {
     ///     Ok(())
     /// }
     /// ```
-    pub fn from_reader<R: Read>(&self, reader: R) -> Reader<R> {
-        Reader::new(self, reader)
+    pub fn from_reader<R: Read>(
+        &self,
+        reader: R,
+        source: Option<String>,
+    ) -> Reader<R> {
+        Reader::new(self, reader, source)
     }
 
     pub fn from_path<P: AsRef<Path>>(
@@ -81,6 +85,7 @@ impl ReaderBuilder {
         path: P,
     ) -> io::Result<Reader<Box<dyn Read>>> {
         let path = path.as_ref();
+        let source = path.to_string_lossy().to_string();
 
         let reader: Box<dyn Read> = match path
             .extension()
@@ -96,22 +101,28 @@ impl ReaderBuilder {
             }
         };
 
-        Ok(self.from_reader(reader))
+        Ok(self.from_reader(reader, Some(source)))
     }
 }
 
 pub struct Reader<R: Read> {
     inner: BufReader<R>,
+    source: Option<String>,
     limit: usize,
     count: usize,
     buf: Vec<u8>,
 }
 
 impl<R: Read> Reader<R> {
-    pub fn new(builder: &ReaderBuilder, reader: R) -> Self {
+    pub fn new(
+        builder: &ReaderBuilder,
+        reader: R,
+        source: Option<String>,
+    ) -> Self {
         Self {
             inner: BufReader::new(reader),
             limit: builder.limit,
+            source,
             buf: vec![],
             count: 0,
         }
@@ -145,7 +156,23 @@ impl<R: Read> RecordsIterator for Reader<R> {
             Ok(_) => {
                 let result = ByteRecord::from_bytes(&self.buf);
                 match result {
-                    Err(e) => Some(Err(ReadPicaError::from(e))),
+                    Err(err) => {
+                        let msg = match &self.source {
+                            Some(source) => {
+                                if source == "-" {
+                                    format!("invalid record in line {} (stdin)", self.count)
+                                } else {
+                                    format!("invalid record in line {} ({})", self.count, source)
+                                }
+                            }
+                            None => format!(
+                                "invalid record on line {}",
+                                self.count
+                            ),
+                        };
+
+                        Some(Err(ReadPicaError::Parse { msg, err }))
+                    }
                     Ok(record) => {
                         self.count += 1;
                         Some(Ok(record))

--- a/src/bin/pica/commands/invalid.rs
+++ b/src/bin/pica/commands/invalid.rs
@@ -34,9 +34,10 @@ impl Invalid {
 
             while let Some(result) = reader.next() {
                 match result {
-                    Err(ReadPicaError::Parse(
-                        ParsePicaError::InvalidRecord(data),
-                    )) => {
+                    Err(ReadPicaError::Parse {
+                        msg: _,
+                        err: ParsePicaError::InvalidRecord(data),
+                    }) => {
                         writer.write_all(&data)?;
                     }
                     Err(e) => return Err(e.into()),

--- a/src/bin/pica/util.rs
+++ b/src/bin/pica/util.rs
@@ -8,7 +8,7 @@ pub(crate) enum CliError {
     Io(io::Error),
     Csv(csv::Error),
     Pica(pica::Error),
-    ParsePica(pica_record::ParsePicaError),
+    ParsePica(String),
     ParsePath(pica_path::ParsePathError),
     ParseMatcher(pica_matcher::ParseMatcherError),
     ParseQuery(pica_select::ParseQueryError),
@@ -52,9 +52,10 @@ impl From<pica_record::io::ReadPicaError> for CliError {
     fn from(err: pica_record::io::ReadPicaError) -> Self {
         match err {
             pica_record::io::ReadPicaError::Io(e) => CliError::Io(e),
-            pica_record::io::ReadPicaError::Parse(e) => {
-                CliError::ParsePica(e)
-            }
+            pica_record::io::ReadPicaError::Parse {
+                msg: m,
+                err: _,
+            } => CliError::ParsePica(m),
         }
     }
 }


### PR DESCRIPTION
This PR print a more helpful error messages if a input line is invalid and can't be decoded as PICA+. 

#### Examples

```
$ pica filter "003@?" tests/data/invalid.dat
Parse Pica Error: invalid record in line 0 (tests/data/invalid.dat)

$ pica filter "003@?" tests/data/dump.dat.gz
Parse Pica Error: invalid record in line 1 (tests/data/dump.dat.gz)

$ echo -e "003@ \x1f0123456789X\x1e\nfoobar\x1e" | pica print
003@ $0 123456789X

Parse Pica Error: invalid record in line 1 (stdin)

$ echo -e "003@ \x1f0123456789X\x1e" | cargo run -- print - tests/data/invalid.dat
003@ $0 123456789X

Parse Pica Error: invalid record in line 0 (tests/data/invalid.dat)
```