### PR TITLE
Add `!^` and `!$` operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #637 Stabilize `print` command
 * #641 Stabilize `sample` command
 * #642 Add `--squash` and `--merge` option
+* #644 Add `!^` and `!$` operator
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -126,10 +126,11 @@ between `/01` and `/10`.
 
 Simple subfield filter consists of the subfield code (single
 alpha-numerical character, ex `0`) a comparison operator (equal `==`,
-not equal `!=` not equal, starts with prefix `=^`, ends with suffix
-`=$`, regex `=~`/`!~`, `in` and `not in`) and a value enclosed in single
-quotes. These simple subfield expressions can be grouped in parentheses
-and combined with boolean connectives (ex. `(0 == 'abc' || 0 == 'def')`).
+not equal `!=` not equal, starts with prefix `=^`, starts not with
+prefix `!^`, ends with suffix `=$`, regex `=~`/`!~`, `in` and `not in`)
+and a value enclosed in single quotes. These simple subfield expressions
+can be grouped in parentheses and combined with boolean connectives (ex.
+`(0 == 'abc' || 0 == 'def')`).
 
 A special existence operator can be used to check if a given field
 (`012A/00?`) or a subfield (`002@.0?` or `002@$0?`) exists.  To test for

--- a/pica-matcher/src/common.rs
+++ b/pica-matcher/src/common.rs
@@ -29,15 +29,17 @@ where
 /// Relational Operator
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RelationalOp {
-    Eq,         // equal, "=="
-    Ne,         // not equal, "!="
-    Gt,         // greater than, ">"
-    Ge,         // greater than or equal, ">="
-    Lt,         // less than, "<"
-    Le,         // less than or equal, "<="
-    StartsWith, // starts with, "=^"
-    EndsWith,   // ends with, "=$"
-    Similar,    // similar, "=*"
+    Eq,            // equal, "=="
+    Ne,            // not equal, "!="
+    Gt,            // greater than, ">"
+    Ge,            // greater than or equal, ">="
+    Lt,            // less than, "<"
+    Le,            // less than or equal, "<="
+    StartsWith,    // starts with, "=^"
+    StartsNotWith, // starts not with, "!^"
+    EndsWith,      // ends with, "=$"
+    EndsNotWith,   // ends not with, "!$"
+    Similar,       // similar, "=*"
 }
 
 impl Display for RelationalOp {
@@ -50,7 +52,9 @@ impl Display for RelationalOp {
             RelationalOp::Lt => write!(f, "<"),
             RelationalOp::Le => write!(f, "<="),
             RelationalOp::StartsWith => write!(f, "=^"),
+            RelationalOp::StartsNotWith => write!(f, "!^"),
             RelationalOp::EndsWith => write!(f, "=$"),
+            RelationalOp::EndsNotWith => write!(f, "!$"),
             RelationalOp::Similar => write!(f, "=*"),
         }
     }
@@ -64,7 +68,9 @@ pub(crate) fn parse_relational_op_str(
         value(RelationalOp::Eq, tag("==")),
         value(RelationalOp::Ne, tag("!=")),
         value(RelationalOp::StartsWith, tag("=^")),
+        value(RelationalOp::StartsNotWith, tag("!^")),
         value(RelationalOp::EndsWith, tag("=$")),
+        value(RelationalOp::EndsNotWith, tag("!$")),
         value(RelationalOp::Similar, tag("=*")),
     ))(i)
 }
@@ -217,8 +223,16 @@ mod tests {
             RelationalOp::StartsWith
         );
         assert_finished_and_eq!(
+            parse_relational_op_str(b"!^"),
+            RelationalOp::StartsNotWith
+        );
+        assert_finished_and_eq!(
             parse_relational_op_str(b"=$"),
             RelationalOp::EndsWith
+        );
+        assert_finished_and_eq!(
+            parse_relational_op_str(b"!$"),
+            RelationalOp::EndsNotWith
         );
         assert_finished_and_eq!(
             parse_relational_op_str(b"=*"),

--- a/tests/snapshot/filter/0113-filter-relation-matcher-curly-starts-not-with-f.stdin
+++ b/tests/snapshot/filter/0113-filter-relation-matcher-curly-starts-not-with-f.stdin
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/tests/snapshot/filter/0113-filter-relation-matcher-curly-starts-not-with-f.toml
+++ b/tests/snapshot/filter/0113-filter-relation-matcher-curly-starts-not-with-f.toml
@@ -1,0 +1,5 @@
+bin.name = "pica"
+args = "filter \"002@{ 0 !^ 'T' }\""
+status = "success"
+stdout = ""
+stderr = ""

--- a/tests/snapshot/filter/0113-filter-relation-matcher-curly-starts-not-with-t.stdin
+++ b/tests/snapshot/filter/0113-filter-relation-matcher-curly-starts-not-with-t.stdin
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/tests/snapshot/filter/0113-filter-relation-matcher-curly-starts-not-with-t.stdout
+++ b/tests/snapshot/filter/0113-filter-relation-matcher-curly-starts-not-with-t.stdout
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/tests/snapshot/filter/0113-filter-relation-matcher-curly-starts-not-with-t.toml
+++ b/tests/snapshot/filter/0113-filter-relation-matcher-curly-starts-not-with-t.toml
@@ -1,0 +1,4 @@
+bin.name = "pica"
+args = "filter \"002@{ 0 !^ 'A' }\""
+status = "success"
+stderr = ""

--- a/tests/snapshot/filter/0113-filter-relation-matcher-simple-starts-not-with-f.stdin
+++ b/tests/snapshot/filter/0113-filter-relation-matcher-simple-starts-not-with-f.stdin
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/tests/snapshot/filter/0113-filter-relation-matcher-simple-starts-not-with-f.toml
+++ b/tests/snapshot/filter/0113-filter-relation-matcher-simple-starts-not-with-f.toml
@@ -1,0 +1,4 @@
+bin.name = "pica"
+args = "filter \"002@.0 !^ 'A'\""
+status = "success"
+stderr = ""

--- a/tests/snapshot/filter/0113-filter-relation-matcher-simple-starts-not-with-t.stdin
+++ b/tests/snapshot/filter/0113-filter-relation-matcher-simple-starts-not-with-t.stdin
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/tests/snapshot/filter/0113-filter-relation-matcher-simple-starts-not-with-t.stdout
+++ b/tests/snapshot/filter/0113-filter-relation-matcher-simple-starts-not-with-t.stdout
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/tests/snapshot/filter/0113-filter-relation-matcher-simple-starts-not-with-t.toml
+++ b/tests/snapshot/filter/0113-filter-relation-matcher-simple-starts-not-with-t.toml
@@ -1,0 +1,5 @@
+bin.name = "pica"
+args = "filter \"002@.0 !^ 'T'\""
+status = "success"
+stdout = ""
+stderr = ""


### PR DESCRIPTION
This PR adds the _starts-not-with_ (`!^`) and the _ends-not-with_ (`!$`) relational operator. The `!^`-operator tests whether a  value starts *not* with the given prefix; and the `!$`-operator tests whether a value doesn't end with a given suffix.

#### Example

```bash
$ pica filter '002@.0 !^ "T"' DUMP.dat.gz -o not-T.dat.gz
$ pica filter '002@{ 0 !$ "1" && 0 !$ "z" }' DUMP.dat.gz -o not-level-1z.dat.gz
```