### PR TITLE
Require `--squash` and `--merge` to be mutually exclusive

### DIFF
--- a/pica-toolkit/src/commands/select.rs
+++ b/pica-toolkit/src/commands/select.rs
@@ -34,10 +34,18 @@ pub(crate) struct Select {
     /// Whether to squash all values of a repeated subfield into a
     /// single value or not. The separator can be specified by the
     /// `--separator` option.
-    #[arg(long)]
+    ///
+    /// Note: This option cannot be used with `--merge`.
+    #[arg(long, conflicts_with = "merge")]
     squash: bool,
 
-    #[arg(long)]
+    /// Whether to merge all values of a column into a single value or
+    /// not. The separator can be specified by the `--separator`
+    /// Note: This option cannot be used with `--merge`.
+    /// option.
+    ///
+    /// Note: This option cannot be used with `--squash`.
+    #[arg(long, conflicts_with = "squash")]
     merge: bool,
 
     /// Sets the separator used for squashing of repeated subfield

--- a/pica-toolkit/tests/snapshot/select/047-select-squash-merge.toml
+++ b/pica-toolkit/tests/snapshot/select/047-select-squash-merge.toml
@@ -1,6 +1,5 @@
 bin.name = "pica"
 args = "select -s \"003@.0,010@.a\" --squash --merge"
-status = "success"
+status = "failed"
 stdin = "003@ \u001f0123456789X\u001e010@ \u001fager\u001faeng\u001e010@ \u001famul\u001e\n"
-stdout = "123456789X,ger|eng|mul\n"
-stderr = ""
+stdout = ""


### PR DESCRIPTION
This PR required `--merge` and `--squash` to be mutually exclusive.