### PR TITLE
Remove deprecated path syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+* #698 Remove deprecated path syntax
+
 
 ## [0.20.0] - 2023-09-14
 

--- a/pica-path/tests/path.rs
+++ b/pica-path/tests/path.rs
@@ -34,14 +34,6 @@ fn test_path_simple() -> anyhow::Result<()> {
 #[test]
 fn test_path_matcher() -> anyhow::Result<()> {
     let record = ByteRecord::from_bytes(ada_lovelace())?;
-    let path = Path::new("065R{4 == 'ortg', 9}");
-
-    assert_eq!(
-        record.path(&path, &Default::default()),
-        vec![&b"040743357".as_bstr()]
-    );
-
-    let record = ByteRecord::from_bytes(ada_lovelace())?;
     let path = Path::new("065R{ 9 | 4 == 'ortg' }");
 
     assert_eq!(

--- a/pica-toolkit/tests/snapshot/frequency/023-frequency-subfield-matcher.toml
+++ b/pica-toolkit/tests/snapshot/frequency/023-frequency-subfield-matcher.toml
@@ -1,5 +1,5 @@
 bin.name = "pica"
-args = "frequency -s \"065R{4 =^ 'ort', 9}\" dump.dat.gz"
+args = "frequency -s \"065R{9 | 4 =^ 'ort'}\" dump.dat.gz"
 status = "success"
 stdout = "041178548,2\n040660095,1\n040787044,1\n"
-stderr = "WARNING: Specifying subfield matcher in the first position of an path expression is deprecated. Please use the set-builder notation instead.\n"
+stderr = ""

--- a/pica-toolkit/tests/snapshot/frequency/024-frequency-subfield-matcher-ci.toml
+++ b/pica-toolkit/tests/snapshot/frequency/024-frequency-subfield-matcher-ci.toml
@@ -1,5 +1,5 @@
 bin.name = "pica"
-args = "frequency -s -i \"065R{4 =^ 'ORT', 9}\" dump.dat.gz"
+args = "frequency -s -i \"065R{9 | 4 =^ 'ORT'}\" dump.dat.gz"
 status = "success"
 stdout = "041178548,2\n040660095,1\n040787044,1\n"
-stderr = "WARNING: Specifying subfield matcher in the first position of an path expression is deprecated. Please use the set-builder notation instead.\n"
+stderr = ""

--- a/pica-toolkit/tests/snapshot/frequency/586-frequency-translit-path1.toml
+++ b/pica-toolkit/tests/snapshot/frequency/586-frequency-translit-path1.toml
@@ -1,5 +1,5 @@
 bin.name = "pica"
-args = "-c Pica.toml frequency \"029@{a =^ 'Städtische', a}\""
+args = "-c Pica.toml frequency \"029@{ a | a =^ 'Städtische'}\""
 status = "success"
 stdout = "Sta\u0308dtische Pressestelle,1\n"
-stderr = "WARNING: Specifying subfield matcher in the first position of an path expression is deprecated. Please use the set-builder notation instead.\n"
+stderr = ""

--- a/pica-toolkit/tests/snapshot/frequency/586-frequency-translit-path2.toml
+++ b/pica-toolkit/tests/snapshot/frequency/586-frequency-translit-path2.toml
@@ -1,5 +1,5 @@
 bin.name = "pica"
-args = "frequency \"029@{a =^ 'Städtische', a}\""
+args = "frequency \"029@{a | a =^ 'Städtische'}\""
 status = "success"
 stdout = ""
-stderr = "WARNING: Specifying subfield matcher in the first position of an path expression is deprecated. Please use the set-builder notation instead.\n"
+stderr = ""

--- a/pica-toolkit/tests/snapshot/select/586-select-translit-selector1.toml
+++ b/pica-toolkit/tests/snapshot/select/586-select-translit-selector1.toml
@@ -1,5 +1,5 @@
 bin.name = "pica"
-args = "-c Pica.toml select -s \"003@.0, 029@{a =^ 'Städtische', a}\""
+args = "-c Pica.toml select -s \"003@.0, 029@{a | a =^ 'Städtische'}\""
 status = "success"
 stdout = "040181189,Sta\u0308dtische Pressestelle\n"
-stderr = "WARNING: Specifying subfield matcher in the first position of an path expression is deprecated. Please use the set-builder notation instead.\n"
+stderr = ""

--- a/pica-toolkit/tests/snapshot/select/586-select-translit-selector2.toml
+++ b/pica-toolkit/tests/snapshot/select/586-select-translit-selector2.toml
@@ -1,6 +1,6 @@
 bin.name = "pica"
-args = "select -s \"003@.0, 029@{a =^ 'Städtische', a}\""
+args = "select -s \"003@.0, 029@{a | a =^ 'Städtische'}\""
 status = "success"
 stdout = "040181189,\n"
-stderr = "WARNING: Specifying subfield matcher in the first position of an path expression is deprecated. Please use the set-builder notation instead.\n"
+stderr = ""
 

--- a/pica-toolkit/tests/snapshot/select/605-false-positives-regex.toml
+++ b/pica-toolkit/tests/snapshot/select/605-false-positives-regex.toml
@@ -1,6 +1,6 @@
 bin.name = "pica"
-args = "select -s \"044K{!9? && a !~ '^:[zf]', a}\""
+args = "select -s \"044K{a | !9? && a !~ '^:[zf]'}\""
 status = "success"
 stdin = "044K \u001fbckw\u001fa:z Geschichte 2005-2017\u001fEa\u001fHstwgnd\u001fK1\u001fD2022-07-15\u001e\n"
 stdout = ""
-stderr = "WARNING: Specifying subfield matcher in the first position of an path expression is deprecated. Please use the set-builder notation instead.\n"
+stderr = ""


### PR DESCRIPTION
This PR removes the deprecated path syntax; please use the "set-builder" notation

```shell
$ pica select '003@.0, 044H{ 9 | b == "GND" }' DUMP.dat.gz
```
instead of

```shell
$ pica select '003@.0, 044H{ b == "GND", 9 }' DUMP.dat.gz
```