### PR TITLE
Fix GitHub deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: abbbi/github-actions-tune@v1
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
           path: |
@@ -39,184 +39,177 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/registry/index/
             target/
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          target: x86_64-unknown-linux-gnu
-          profile: minimal
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --workspace
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: |
+          make check
 
-  test:
-    name: test ${{ matrix.target.triple }} (${{ matrix.target.toolchain }})
-    needs: check
-    strategy:
-      matrix:
-        target:
-          - { os: ubuntu-latest, toolchain: stable, triple: x86_64-unknown-linux-gnu }
-          - { os: ubuntu-latest, toolchain: beta, triple: x86_64-unknown-linux-gnu }
-          - { os: ubuntu-latest, toolchain: nightly, triple: x86_64-unknown-linux-gnu }
-          - { os: macos-latest, toolchain: stable, triple: x86_64-apple-darwin }
-          - { os: macos-latest, toolchain: beta, triple: x86_64-apple-darwin }
-          - { os: macos-latest, toolchain: nightly, triple: x86_64-apple-darwin }
-          - { os: windows-latest, toolchain: stable, triple: x86_64-pc-windows-gnu }
-          - { os: windows-latest, toolchain: stable, triple: i686-pc-windows-msvc }
-    runs-on: ${{ matrix.target.os }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: abbbi/github-actions-tune@v1
-        if: ${{ matrix.target.os == 'ubuntu-latest' }}
-      - uses: actions/cache@v2
-        with:
-          key: ${{ runner.os }}-cargo-${{ matrix.target.toolchain }}-${{ matrix.target.triple }}-${{ hashFiles('**/Cargo.toml') }}
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/git/db/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/index/
-            target/
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.target.toolchain }}
-          target: ${{ matrix.target.triple }}
-          profile: minimal
-          override: true
-      - name: "Run prepare tests"
-        run: ci/prepare-tests.sh
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-features --no-fail-fast
+  # test:
+  #   name: test ${{ matrix.target.triple }} (${{ matrix.target.toolchain }})
+  #   needs: check
+  #   strategy:
+  #     matrix:
+  #       target:
+  #         - { os: ubuntu-latest, toolchain: stable, triple: x86_64-unknown-linux-gnu }
+  #         - { os: ubuntu-latest, toolchain: beta, triple: x86_64-unknown-linux-gnu }
+  #         - { os: ubuntu-latest, toolchain: nightly, triple: x86_64-unknown-linux-gnu }
+  #         - { os: macos-latest, toolchain: stable, triple: x86_64-apple-darwin }
+  #         - { os: macos-latest, toolchain: beta, triple: x86_64-apple-darwin }
+  #         - { os: macos-latest, toolchain: nightly, triple: x86_64-apple-darwin }
+  #         - { os: windows-latest, toolchain: stable, triple: x86_64-pc-windows-gnu }
+  #         - { os: windows-latest, toolchain: stable, triple: i686-pc-windows-msvc }
+  #   runs-on: ${{ matrix.target.os }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: abbbi/github-actions-tune@v1
+  #       if: ${{ matrix.target.os == 'ubuntu-latest' }}
+  #     - uses: actions/cache@v2
+  #       with:
+  #         key: ${{ runner.os }}-cargo-${{ matrix.target.toolchain }}-${{ matrix.target.triple }}-${{ hashFiles('**/Cargo.toml') }}
+  #         path: |
+  #           ~/.cargo/bin/
+  #           ~/.cargo/git/db/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/registry/index/
+  #           target/
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: ${{ matrix.target.toolchain }}
+  #         target: ${{ matrix.target.triple }}
+  #         profile: minimal
+  #         override: true
+  #     - name: "Run prepare tests"
+  #       run: ci/prepare-tests.sh
+  #     - uses: actions-rs/cargo@v1
+  #       with:
+  #         command: test
+  #         args: --workspace --all-features --no-fail-fast
 
-  cross:
-    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
-    name: cross ${{ matrix.target.triple }} (${{ matrix.target.toolchain }})
-    runs-on: ${{ matrix.target.os }}
-    needs: check
-    strategy:
-      matrix:
-        target:
-          - { os: ubuntu-latest, toolchain: stable, triple: x86_64-unknown-linux-gnu }
-          - { os: ubuntu-latest, toolchain: beta, triple: x86_64-unknown-linux-gnu }
-          - { os: ubuntu-latest, toolchain: nightly, triple: x86_64-unknown-linux-gnu }
-          - { os: ubuntu-latest, toolchain: stable, triple: x86_64-unknown-linux-musl }
-          - { os: ubuntu-latest, toolchain: stable, triple: aarch64-unknown-linux-gnu }
-          - { os: ubuntu-latest, toolchain: stable, triple: aarch64-unknown-linux-musl }
-    steps:
-      - uses: actions/checkout@v3
-      - uses: abbbi/github-actions-tune@v1
-        if: ${{ matrix.target.os == 'ubuntu-latest' }}
-      - uses: actions/cache@v2
-        with:
-          key: ${{ runner.os }}-cargo-cross-${{ matrix.target.toolchain }}-${{ matrix.target.triple }}-${{ hashFiles('**/Cargo.toml') }}
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/git/db/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/index/
-            target/
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.target.toolchain }}
-          target: ${{ matrix.target.triple }}
-          profile: minimal
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --workspace --all-features
+  # cross:
+  #   if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+  #   name: cross ${{ matrix.target.triple }} (${{ matrix.target.toolchain }})
+  #   runs-on: ${{ matrix.target.os }}
+  #   needs: check
+  #   strategy:
+  #     matrix:
+  #       target:
+  #         - { os: ubuntu-latest, toolchain: stable, triple: x86_64-unknown-linux-gnu }
+  #         - { os: ubuntu-latest, toolchain: beta, triple: x86_64-unknown-linux-gnu }
+  #         - { os: ubuntu-latest, toolchain: nightly, triple: x86_64-unknown-linux-gnu }
+  #         - { os: ubuntu-latest, toolchain: stable, triple: x86_64-unknown-linux-musl }
+  #         - { os: ubuntu-latest, toolchain: stable, triple: aarch64-unknown-linux-gnu }
+  #         - { os: ubuntu-latest, toolchain: stable, triple: aarch64-unknown-linux-musl }
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: abbbi/github-actions-tune@v1
+  #       if: ${{ matrix.target.os == 'ubuntu-latest' }}
+  #     - uses: actions/cache@v2
+  #       with:
+  #         key: ${{ runner.os }}-cargo-cross-${{ matrix.target.toolchain }}-${{ matrix.target.triple }}-${{ hashFiles('**/Cargo.toml') }}
+  #         path: |
+  #           ~/.cargo/bin/
+  #           ~/.cargo/git/db/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/registry/index/
+  #           target/
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: ${{ matrix.target.toolchain }}
+  #         target: ${{ matrix.target.triple }}
+  #         profile: minimal
+  #         override: true
+  #     - uses: actions-rs/cargo@v1
+  #       with:
+  #         use-cross: true
+  #         command: build
+  #         args: --workspace --all-features
 
-  fuzz:
-    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
-    name: fuzz ${{ matrix.item.name }}
-    runs-on: ubuntu-latest
-    needs: check
-    strategy:
-      matrix:
-        item:
-          - { name: record_ref, fuzz-dir: crates/pica-record/fuzz, target: fuzz_record_ref, max-total-time: 300 }
-          - { name: select_query, fuzz-dir: crates/pica-select/fuzz, target: fuzz_query, max-total-time: 300 }
-    steps:
-      - uses: actions/checkout@v3
-      - uses: abbbi/github-actions-tune@v1
-      - uses: actions/cache@v2
-        with:
-          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/git/db/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/index/
-            target/
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-fuzz
-          version: latest
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fuzz
-          args: run --fuzz-dir ${{ matrix.item.fuzz-dir }} --jobs 2 ${{ matrix.item.target }} -- -max_total_time=${{ matrix.item.max-total-time }}
+  # fuzz:
+  #   if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+  #   name: fuzz ${{ matrix.item.name }}
+  #   runs-on: ubuntu-latest
+  #   needs: check
+  #   strategy:
+  #     matrix:
+  #       item:
+  #         - { name: record_ref, fuzz-dir: crates/pica-record/fuzz, target: fuzz_record_ref, max-total-time: 300 }
+  #         - { name: select_query, fuzz-dir: crates/pica-select/fuzz, target: fuzz_query, max-total-time: 300 }
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: abbbi/github-actions-tune@v1
+  #     - uses: actions/cache@v2
+  #       with:
+  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+  #         path: |
+  #           ~/.cargo/bin/
+  #           ~/.cargo/git/db/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/registry/index/
+  #           target/
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: nightly
+  #         override: true
+  #     - uses: actions-rs/install@v0.1
+  #       with:
+  #         crate: cargo-fuzz
+  #         version: latest
+  #     - uses: actions-rs/cargo@v1
+  #       with:
+  #         command: fuzz
+  #         args: run --fuzz-dir ${{ matrix.item.fuzz-dir }} --jobs 2 ${{ matrix.item.target }} -- -max_total_time=${{ matrix.item.max-total-time }}
 
-  fmt:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v3
-      - uses: abbbi/github-actions-tune@v1
-      - uses: actions/cache@v2
-        with:
-          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/git/db/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/index/
-            target/
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+  # fmt:
+  #   runs-on: ubuntu-latest
+  #   needs: test
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: abbbi/github-actions-tune@v1
+  #     - uses: actions/cache@v2
+  #       with:
+  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+  #         path: |
+  #           ~/.cargo/bin/
+  #           ~/.cargo/git/db/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/registry/index/
+  #           target/
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: nightly
+  #         override: true
+  #         components: rustfmt
+  #     - uses: actions-rs/cargo@v1
+  #       with:
+  #         command: fmt
+  #         args: --all -- --check
 
-  clippy:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v3
-      - uses: abbbi/github-actions-tune@v1
-      - uses: actions/cache@v2
-        with:
-          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/git/db/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/index/
-            target/
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace -- -D warnings -D rust-2021-compatibility -W unreachable-pub
+  # clippy:
+  #   runs-on: ubuntu-latest
+  #   needs: test
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: abbbi/github-actions-tune@v1
+  #     - uses: actions/cache@v2
+  #       with:
+  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+  #         path: |
+  #           ~/.cargo/bin/
+  #           ~/.cargo/git/db/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/registry/index/
+  #           target/
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: nightly
+  #         override: true
+  #         components: clippy
+  #     - uses: actions-rs/cargo@v1
+  #       with:
+  #         command: clippy
+  #         args: --workspace -- -D warnings -D rust-2021-compatibility -W unreachable-pub
 
   # udeps:
   #   if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
@@ -248,177 +241,177 @@ jobs:
   #         command: udeps
   #         args: --workspace
 
-  audit:
-    if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v3
-      - uses: abbbi/github-actions-tune@v1
-      - uses: actions/cache@v2
-        with:
-          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/git/db/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/index/
-            target/
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+  # audit:
+  #   if: ${{ github.ref == 'refs/heads/main' }}
+  #   runs-on: ubuntu-latest
+  #   needs: test
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: abbbi/github-actions-tune@v1
+  #     - uses: actions/cache@v2
+  #       with:
+  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+  #         path: |
+  #           ~/.cargo/bin/
+  #           ~/.cargo/git/db/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/registry/index/
+  #           target/
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: nightly
+  #         override: true
+  #     - uses: actions-rs/audit-check@v1
+  #       with:
+  #         token: ${{ secrets.GITHUB_TOKEN }}
 
-  upgrades:
-    if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v3
-      - uses: abbbi/github-actions-tune@v1
-      - uses: actions/cache@v2
-        with:
-          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/git/db/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/index/
-            target/
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-upgrades
-          version: latest
-      - run: |
-          cargo upgrades
+  # upgrades:
+  #   if: ${{ github.ref == 'refs/heads/main' }}
+  #   runs-on: ubuntu-latest
+  #   needs: test
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: abbbi/github-actions-tune@v1
+  #     - uses: actions/cache@v2
+  #       with:
+  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+  #         path: |
+  #           ~/.cargo/bin/
+  #           ~/.cargo/git/db/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/registry/index/
+  #           target/
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: nightly
+  #         override: true
+  #     - uses: actions-rs/install@v0.1
+  #       with:
+  #         crate: cargo-upgrades
+  #         version: latest
+  #     - run: |
+  #         cargo upgrades
 
-  deny:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v3
-      - uses: abbbi/github-actions-tune@v1
-      - uses: actions/cache@v2
-        with:
-          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/git/db/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/index/
-            target/
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: clippy
-      - uses: EmbarkStudios/cargo-deny-action@v1
-        with:
-          log-level: warn
-          command: check
-          arguments: --workspace
+  # deny:
+  #   runs-on: ubuntu-latest
+  #   needs: test
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: abbbi/github-actions-tune@v1
+  #     - uses: actions/cache@v2
+  #       with:
+  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+  #         path: |
+  #           ~/.cargo/bin/
+  #           ~/.cargo/git/db/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/registry/index/
+  #           target/
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: nightly
+  #         override: true
+  #         components: clippy
+  #     - uses: EmbarkStudios/cargo-deny-action@v1
+  #       with:
+  #         log-level: warn
+  #         command: check
+  #         arguments: --workspace
 
-  miri:
-    name: miri
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@miri
-    - run: cargo miri test --workspace --lib --verbose
-      env:
-        MIRIFLAGS: -Zmiri-strict-provenance
-    - run: cargo miri test --workspace --doc --verbose
-      env:
-        MIRIFLAGS: -Zmiri-strict-provenance
+  # miri:
+  #   name: miri
+  #   runs-on: ubuntu-latest
+  #   needs: test
+  #   steps:
+  #   - name: Checkout repository
+  #     uses: actions/checkout@v3
+  #   - name: Install Rust
+  #     uses: dtolnay/rust-toolchain@miri
+  #   - run: cargo miri test --workspace --lib --verbose
+  #     env:
+  #       MIRIFLAGS: -Zmiri-strict-provenance
+  #   - run: cargo miri test --workspace --doc --verbose
+  #     env:
+  #       MIRIFLAGS: -Zmiri-strict-provenance
 
-  book:
-    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v3
-      - uses: abbbi/github-actions-tune@v1
-      - uses: actions/cache@v2
-        with:
-          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/git/db/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/index/
-            target/
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/install@v0.1
-        with:
-          version: latest
-          crate: mdbook
-      - run: |
-          mdbook build docs/book
-          mdbook test docs/book
+  # book:
+  #   if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+  #   runs-on: ubuntu-latest
+  #   needs: test
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: abbbi/github-actions-tune@v1
+  #     - uses: actions/cache@v2
+  #       with:
+  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+  #         path: |
+  #           ~/.cargo/bin/
+  #           ~/.cargo/git/db/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/registry/index/
+  #           target/
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: nightly
+  #         override: true
+  #     - uses: actions-rs/install@v0.1
+  #       with:
+  #         version: latest
+  #         crate: mdbook
+  #     - run: |
+  #         mdbook build docs/book
+  #         mdbook test docs/book
 
-  gh-pages:
-    if: ${{ github.ref == 'refs/heads/main' }}
-    needs:
-      - audit
-      - book
-      - check
-      - clippy
-      - cross
-      - deny
-      - fmt
-      - fuzz
-      - miri
-      - test
-      # - udeps
-      - upgrades
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: abbbi/github-actions-tune@v1
-      - uses: actions/cache@v2
-        with:
-          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/git/db/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/index/
-            target/
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/install@v0.1
-        with:
-          version: latest
-          crate: mdbook
-      - run: |
-          mkdir -p target/docs
-          cargo doc --all --no-deps --workspace --target-dir target/docs/api
-          mdbook build docs/book --dest-dir ../../target/docs/book
-          echo '<meta http-equiv="refresh" content="0; url=doc/pica/index.html"><a href=doc/pica/index.html">Redirect</a>' >> target/docs/api/index.html
-          echo '<meta http-equiv="refresh" content="0; url=book/index.html"><a href=book/index.html">Redirect</a>' >> target/docs/index.html
-      - uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: target/docs
-          keep_files: false
-          force_orphan: true
+  # gh-pages:
+  #   if: ${{ github.ref == 'refs/heads/main' }}
+  #   needs:
+  #     - audit
+  #     - book
+  #     - check
+  #     - clippy
+  #     - cross
+  #     - deny
+  #     - fmt
+  #     - fuzz
+  #     - miri
+  #     - test
+  #     # - udeps
+  #     - upgrades
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: abbbi/github-actions-tune@v1
+  #     - uses: actions/cache@v2
+  #       with:
+  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+  #         path: |
+  #           ~/.cargo/bin/
+  #           ~/.cargo/git/db/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/registry/index/
+  #           target/
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: nightly
+  #         override: true
+  #     - uses: actions-rs/install@v0.1
+  #       with:
+  #         version: latest
+  #         crate: mdbook
+  #     - run: |
+  #         mkdir -p target/docs
+  #         cargo doc --all --no-deps --workspace --target-dir target/docs/api
+  #         mdbook build docs/book --dest-dir ../../target/docs/book
+  #         echo '<meta http-equiv="refresh" content="0; url=doc/pica/index.html"><a href=doc/pica/index.html">Redirect</a>' >> target/docs/api/index.html
+  #         echo '<meta http-equiv="refresh" content="0; url=book/index.html"><a href=book/index.html">Redirect</a>' >> target/docs/index.html
+  #     - uses: peaceiris/actions-gh-pages@v3
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         publish_dir: target/docs
+  #         keep_files: false
+  #         force_orphan: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,46 +43,42 @@ jobs:
       - run: |
           make check
 
-  # test:
-  #   name: test ${{ matrix.target.triple }} (${{ matrix.target.toolchain }})
-  #   needs: check
-  #   strategy:
-  #     matrix:
-  #       target:
-  #         - { os: ubuntu-latest, toolchain: stable, triple: x86_64-unknown-linux-gnu }
-  #         - { os: ubuntu-latest, toolchain: beta, triple: x86_64-unknown-linux-gnu }
-  #         - { os: ubuntu-latest, toolchain: nightly, triple: x86_64-unknown-linux-gnu }
-  #         - { os: macos-latest, toolchain: stable, triple: x86_64-apple-darwin }
-  #         - { os: macos-latest, toolchain: beta, triple: x86_64-apple-darwin }
-  #         - { os: macos-latest, toolchain: nightly, triple: x86_64-apple-darwin }
-  #         - { os: windows-latest, toolchain: stable, triple: x86_64-pc-windows-gnu }
-  #         - { os: windows-latest, toolchain: stable, triple: i686-pc-windows-msvc }
-  #   runs-on: ${{ matrix.target.os }}
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: abbbi/github-actions-tune@v1
-  #       if: ${{ matrix.target.os == 'ubuntu-latest' }}
-  #     - uses: actions/cache@v2
-  #       with:
-  #         key: ${{ runner.os }}-cargo-${{ matrix.target.toolchain }}-${{ matrix.target.triple }}-${{ hashFiles('**/Cargo.toml') }}
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/git/db/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/registry/index/
-  #           target/
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: ${{ matrix.target.toolchain }}
-  #         target: ${{ matrix.target.triple }}
-  #         profile: minimal
-  #         override: true
-  #     - name: "Run prepare tests"
-  #       run: ci/prepare-tests.sh
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: test
-  #         args: --workspace --all-features --no-fail-fast
+  test:
+    name: test ${{ matrix.target.triple }} (${{ matrix.target.toolchain }})
+    needs: check
+    strategy:
+      matrix:
+        target:
+          - { os: ubuntu-latest, toolchain: stable, triple: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-latest, toolchain: beta, triple: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-latest, toolchain: nightly, triple: x86_64-unknown-linux-gnu }
+          - { os: macos-latest, toolchain: stable, triple: x86_64-apple-darwin }
+          - { os: macos-latest, toolchain: beta, triple: x86_64-apple-darwin }
+          - { os: macos-latest, toolchain: nightly, triple: x86_64-apple-darwin }
+          - { os: windows-latest, toolchain: stable, triple: x86_64-pc-windows-gnu }
+          - { os: windows-latest, toolchain: stable, triple: i686-pc-windows-msvc }
+    runs-on: ${{ matrix.target.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: abbbi/github-actions-tune@v1
+        if: ${{ matrix.target.os == 'ubuntu-latest' }}
+      - uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-cargo-${{ matrix.target.toolchain }}-${{ matrix.target.triple }}-${{ hashFiles('**/Cargo.toml') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/git/db/
+            ~/.cargo/registry/cache/
+            ~/.cargo/registry/index/
+            target/
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.target.toolchain }}
+          targets: ${{ matrix.target.triple }}
+      - name: "Run prepare tests"
+        run: ci/prepare-tests.sh
+      - run: |
+          make test
 
   # cross:
   #   if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - name: "Install cargo-fuzz"
         run: |
-          cargo install cargo-fuzz
+          cargo install -f cargo-fuzz
       - run: |
           cargo fuzz run --fuzz-dir ${{ matrix.item.fuzz-dir }} --jobs 2 ${{ matrix.item.target }} -- -max_total_time=${{ matrix.item.max-total-time }}
 
@@ -187,28 +187,28 @@ jobs:
       - run: |
           cargo clippy --workspace -- -D warnings -D rust-2021-compatibility -W unreachable-pub
 
-  udeps:
-    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v4
-      - uses: abbbi/github-actions-tune@v1
-      - uses: actions/cache@v3
-        with:
-          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/git/db/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/index/
-            target/
-      - uses: dtolnay/rust-toolchain@nightly
-      - name: "Install `cargo-udeps`"
-        run: |
-          cargo install -f cargo-udeps
-      - run: |
-          cargo udeps --workspace
+  # udeps:
+  #   if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+  #   runs-on: ubuntu-latest
+  #   needs: test
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: abbbi/github-actions-tune@v1
+  #     - uses: actions/cache@v3
+  #       with:
+  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+  #         path: |
+  #           ~/.cargo/bin/
+  #           ~/.cargo/git/db/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/registry/index/
+  #           target/
+  #     - uses: dtolnay/rust-toolchain@nightly
+  #     - name: "Install `cargo-udeps`"
+  #       run: |
+  #         cargo install -f cargo-udeps
+  #     - run: |
+  #         cargo udeps --workspace
 
   audit:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
           cargo udeps --workspace
 
   audit:
-    # if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     needs: test
     steps:
@@ -232,7 +232,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   upgrades:
-    # if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     needs: test
     steps:
@@ -291,81 +291,71 @@ jobs:
       env:
         MIRIFLAGS: -Zmiri-strict-provenance
 
-  # book:
-  #   if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: abbbi/github-actions-tune@v1
-  #     - uses: actions/cache@v2
-  #       with:
-  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/git/db/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/registry/index/
-  #           target/
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: nightly
-  #         override: true
-  #     - uses: actions-rs/install@v0.1
-  #       with:
-  #         version: latest
-  #         crate: mdbook
-  #     - run: |
-  #         mdbook build docs/book
-  #         mdbook test docs/book
+  book:
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: abbbi/github-actions-tune@v1
+      - uses: actions/cache@v3
+        with:
+          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/git/db/
+            ~/.cargo/registry/cache/
+            ~/.cargo/registry/index/
+            target/
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: "Install `mdbook`"
+        run: |
+          cargo install -f mdbook
+      - run: |
+          mdbook build docs/book
+          mdbook test docs/book
 
-  # gh-pages:
-  #   if: ${{ github.ref == 'refs/heads/main' }}
-  #   needs:
-  #     - audit
-  #     - book
-  #     - check
-  #     - clippy
-  #     - cross
-  #     - deny
-  #     - fmt
-  #     - fuzz
-  #     - miri
-  #     - test
-  #     # - udeps
-  #     - upgrades
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: abbbi/github-actions-tune@v1
-  #     - uses: actions/cache@v2
-  #       with:
-  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/git/db/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/registry/index/
-  #           target/
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: nightly
-  #         override: true
-  #     - uses: actions-rs/install@v0.1
-  #       with:
-  #         version: latest
-  #         crate: mdbook
-  #     - run: |
-  #         mkdir -p target/docs
-  #         cargo doc --all --no-deps --workspace --target-dir target/docs/api
-  #         mdbook build docs/book --dest-dir ../../target/docs/book
-  #         echo '<meta http-equiv="refresh" content="0; url=doc/pica/index.html"><a href=doc/pica/index.html">Redirect</a>' >> target/docs/api/index.html
-  #         echo '<meta http-equiv="refresh" content="0; url=book/index.html"><a href=book/index.html">Redirect</a>' >> target/docs/index.html
-  #     - uses: peaceiris/actions-gh-pages@v3
-  #       with:
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #         publish_dir: target/docs
-  #         keep_files: false
-  #         force_orphan: true
+  gh-pages:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs:
+      - audit
+      - book
+      - check
+      - clippy
+      - cross
+      - deny
+      - fmt
+      - fuzz
+      - miri
+      - test
+      # - udeps
+      - upgrades
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: abbbi/github-actions-tune@v1
+      - uses: actions/cache@v3
+        with:
+          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/git/db/
+            ~/.cargo/registry/cache/
+            ~/.cargo/registry/index/
+            target/
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: "Install `mdbook`"
+        run: |
+          cargo install -f mdbook
+      - run: |
+          mkdir -p target/docs
+          cargo doc --all --no-deps --workspace --target-dir target/docs/api
+          mdbook build docs/book --dest-dir ../../target/docs/book
+          echo '<meta http-equiv="refresh" content="0; url=doc/pica/index.html"><a href=doc/pica/index.html">Redirect</a>' >> target/docs/api/index.html
+          echo '<meta http-equiv="refresh" content="0; url=book/index.html"><a href=book/index.html">Redirect</a>' >> target/docs/index.html
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: target/docs
+          keep_files: false
+          force_orphan: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,183 +145,151 @@ jobs:
       - run: |
           cargo fuzz run --fuzz-dir ${{ matrix.item.fuzz-dir }} --jobs 2 ${{ matrix.item.target }} -- -max_total_time=${{ matrix.item.max-total-time }}
 
-  # fmt:
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: abbbi/github-actions-tune@v1
-  #     - uses: actions/cache@v2
-  #       with:
-  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/git/db/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/registry/index/
-  #           target/
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: nightly
-  #         override: true
-  #         components: rustfmt
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: fmt
-  #         args: --all -- --check
+  fmt:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: abbbi/github-actions-tune@v1
+      - uses: actions/cache@v3
+        with:
+          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/git/db/
+            ~/.cargo/registry/cache/
+            ~/.cargo/registry/index/
+            target/
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: |
+          cargo fmt --all -- --check
 
-  # clippy:
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: abbbi/github-actions-tune@v1
-  #     - uses: actions/cache@v2
-  #       with:
-  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/git/db/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/registry/index/
-  #           target/
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: nightly
-  #         override: true
-  #         components: clippy
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: clippy
-  #         args: --workspace -- -D warnings -D rust-2021-compatibility -W unreachable-pub
+  clippy:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: abbbi/github-actions-tune@v1
+      - uses: actions/cache@v3
+        with:
+          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/git/db/
+            ~/.cargo/registry/cache/
+            ~/.cargo/registry/index/
+            target/
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
+      - run: |
+          cargo clippy --workspace -- -D warnings -D rust-2021-compatibility -W unreachable-pub
 
-  # udeps:
-  #   if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: abbbi/github-actions-tune@v1
-  #     - uses: actions/cache@v2
-  #       with:
-  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/git/db/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/registry/index/
-  #           target/
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: nightly
-  #         override: true
-  #     - uses: actions-rs/install@v0.1
-  #       with:
-  #         crate: cargo-udeps
-  #         version: latest
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: udeps
-  #         args: --workspace
+  udeps:
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: abbbi/github-actions-tune@v1
+      - uses: actions/cache@v3
+        with:
+          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/git/db/
+            ~/.cargo/registry/cache/
+            ~/.cargo/registry/index/
+            target/
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: "Install `cargo-udeps`"
+        run: |
+          cargo install -f cargo-udeps
+      - run: |
+          cargo udeps --workspace
 
-  # audit:
-  #   if: ${{ github.ref == 'refs/heads/main' }}
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: abbbi/github-actions-tune@v1
-  #     - uses: actions/cache@v2
-  #       with:
-  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/git/db/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/registry/index/
-  #           target/
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: nightly
-  #         override: true
-  #     - uses: actions-rs/audit-check@v1
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
+  audit:
+    # if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: abbbi/github-actions-tune@v1
+      - uses: actions/cache@v3
+        with:
+          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/git/db/
+            ~/.cargo/registry/cache/
+            ~/.cargo/registry/index/
+            target/
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-  # upgrades:
-  #   if: ${{ github.ref == 'refs/heads/main' }}
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: abbbi/github-actions-tune@v1
-  #     - uses: actions/cache@v2
-  #       with:
-  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/git/db/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/registry/index/
-  #           target/
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: nightly
-  #         override: true
-  #     - uses: actions-rs/install@v0.1
-  #       with:
-  #         crate: cargo-upgrades
-  #         version: latest
-  #     - run: |
-  #         cargo upgrades
+  upgrades:
+    # if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: abbbi/github-actions-tune@v1
+      - uses: actions/cache@v3
+        with:
+          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/git/db/
+            ~/.cargo/registry/cache/
+            ~/.cargo/registry/index/
+            target/
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: "Install `cargo-upgrades`"
+        run: |
+          cargo install -f cargo-upgrades
+      - run: |
+          cargo upgrades
 
-  # deny:
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: abbbi/github-actions-tune@v1
-  #     - uses: actions/cache@v2
-  #       with:
-  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/git/db/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/registry/index/
-  #           target/
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: nightly
-  #         override: true
-  #         components: clippy
-  #     - uses: EmbarkStudios/cargo-deny-action@v1
-  #       with:
-  #         log-level: warn
-  #         command: check
-  #         arguments: --workspace
+  deny:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: abbbi/github-actions-tune@v1
+      - uses: actions/cache@v3
+        with:
+          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/git/db/
+            ~/.cargo/registry/cache/
+            ~/.cargo/registry/index/
+            target/
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          log-level: warn
+          command: check
+          arguments: --workspace
 
-  # miri:
-  #   name: miri
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   steps:
-  #   - name: Checkout repository
-  #     uses: actions/checkout@v3
-  #   - name: Install Rust
-  #     uses: dtolnay/rust-toolchain@miri
-  #   - run: cargo miri test --workspace --lib --verbose
-  #     env:
-  #       MIRIFLAGS: -Zmiri-strict-provenance
-  #   - run: cargo miri test --workspace --doc --verbose
-  #     env:
-  #       MIRIFLAGS: -Zmiri-strict-provenance
+  miri:
+    name: miri
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@miri
+    - run: cargo miri test --workspace --lib --verbose
+      env:
+        MIRIFLAGS: -Zmiri-strict-provenance
+    - run: cargo miri test --workspace --doc --verbose
+      env:
+        MIRIFLAGS: -Zmiri-strict-provenance
 
   # book:
   #   if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           toolchain: ${{ matrix.target.toolchain }}
           targets: ${{ matrix.target.triple }}
       - name: "Install cross"
-        run: cargo install cross
+        run: cargo install -f cross
       - run: |
           cross build --target ${{ matrix.target.triple }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,41 +116,34 @@ jobs:
       - run: |
           cross build --target ${{ matrix.target.triple }}
 
-  # fuzz:
-  #   if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
-  #   name: fuzz ${{ matrix.item.name }}
-  #   runs-on: ubuntu-latest
-  #   needs: check
-  #   strategy:
-  #     matrix:
-  #       item:
-  #         - { name: record_ref, fuzz-dir: crates/pica-record/fuzz, target: fuzz_record_ref, max-total-time: 300 }
-  #         - { name: select_query, fuzz-dir: crates/pica-select/fuzz, target: fuzz_query, max-total-time: 300 }
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: abbbi/github-actions-tune@v1
-  #     - uses: actions/cache@v2
-  #       with:
-  #         key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/git/db/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/registry/index/
-  #           target/
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: nightly
-  #         override: true
-  #     - uses: actions-rs/install@v0.1
-  #       with:
-  #         crate: cargo-fuzz
-  #         version: latest
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: fuzz
-  #         args: run --fuzz-dir ${{ matrix.item.fuzz-dir }} --jobs 2 ${{ matrix.item.target }} -- -max_total_time=${{ matrix.item.max-total-time }}
+  fuzz:
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+    name: fuzz ${{ matrix.item.name }}
+    runs-on: ubuntu-latest
+    needs: check
+    strategy:
+      matrix:
+        item:
+          - { name: record_ref, fuzz-dir: crates/pica-record/fuzz, target: fuzz_record_ref, max-total-time: 300 }
+          - { name: select_query, fuzz-dir: crates/pica-select/fuzz, target: fuzz_query, max-total-time: 300 }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: abbbi/github-actions-tune@v1
+      - uses: actions/cache@v3
+        with:
+          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/git/db/
+            ~/.cargo/registry/cache/
+            ~/.cargo/registry/index/
+            target/
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: "Install cargo-fuzz"
+        run: |
+          cargo install cargo-fuzz
+      - run: |
+          cargo fuzz run --fuzz-dir ${{ matrix.item.fuzz-dir }} --jobs 2 ${{ matrix.item.target }} -- -max_total_time=${{ matrix.item.max-total-time }}
 
   # fmt:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,44 +80,41 @@ jobs:
       - run: |
           make test
 
-  # cross:
-  #   if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
-  #   name: cross ${{ matrix.target.triple }} (${{ matrix.target.toolchain }})
-  #   runs-on: ${{ matrix.target.os }}
-  #   needs: check
-  #   strategy:
-  #     matrix:
-  #       target:
-  #         - { os: ubuntu-latest, toolchain: stable, triple: x86_64-unknown-linux-gnu }
-  #         - { os: ubuntu-latest, toolchain: beta, triple: x86_64-unknown-linux-gnu }
-  #         - { os: ubuntu-latest, toolchain: nightly, triple: x86_64-unknown-linux-gnu }
-  #         - { os: ubuntu-latest, toolchain: stable, triple: x86_64-unknown-linux-musl }
-  #         - { os: ubuntu-latest, toolchain: stable, triple: aarch64-unknown-linux-gnu }
-  #         - { os: ubuntu-latest, toolchain: stable, triple: aarch64-unknown-linux-musl }
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: abbbi/github-actions-tune@v1
-  #       if: ${{ matrix.target.os == 'ubuntu-latest' }}
-  #     - uses: actions/cache@v2
-  #       with:
-  #         key: ${{ runner.os }}-cargo-cross-${{ matrix.target.toolchain }}-${{ matrix.target.triple }}-${{ hashFiles('**/Cargo.toml') }}
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/git/db/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/registry/index/
-  #           target/
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: ${{ matrix.target.toolchain }}
-  #         target: ${{ matrix.target.triple }}
-  #         profile: minimal
-  #         override: true
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         use-cross: true
-  #         command: build
-  #         args: --workspace --all-features
+  cross:
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+    name: cross ${{ matrix.target.triple }} (${{ matrix.target.toolchain }})
+    runs-on: ${{ matrix.target.os }}
+    needs: check
+    strategy:
+      matrix:
+        target:
+          - { os: ubuntu-latest, toolchain: stable, triple: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-latest, toolchain: beta, triple: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-latest, toolchain: nightly, triple: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-latest, toolchain: stable, triple: x86_64-unknown-linux-musl }
+          - { os: ubuntu-latest, toolchain: stable, triple: aarch64-unknown-linux-gnu }
+          - { os: ubuntu-latest, toolchain: stable, triple: aarch64-unknown-linux-musl }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: abbbi/github-actions-tune@v1
+        if: ${{ matrix.target.os == 'ubuntu-latest' }}
+      - uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-cargo-cross-${{ matrix.target.toolchain }}-${{ matrix.target.triple }}-${{ hashFiles('**/Cargo.toml') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/git/db/
+            ~/.cargo/registry/cache/
+            ~/.cargo/registry/index/
+            target/
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.target.toolchain }}
+          targets: ${{ matrix.target.triple }}
+      - name: "Install cross"
+        run: cargo install cross
+      - run: |
+          cross build --target ${{ matrix.target.triple }}
 
   # fuzz:
   #   if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -9,9 +9,9 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: abbbi/github-actions-tune@v1
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-cargo-stable-${{ hashFiles('**/Cargo.toml') }}
           path: |
@@ -20,10 +20,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/registry/index/
             target/
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -31,9 +28,9 @@ jobs:
   upgrades:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: abbbi/github-actions-tune@v1
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/Cargo.toml') }}
           path: |
@@ -42,12 +39,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/registry/index/
             target/
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - run: |
+      - uses: dtolnay/rust-toolchain@stable
+      - name: "Install `cargo-upgrades`"
+        run: |
           cargo install -f cargo-upgrades
       - run: |
           cargo upgrades

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,6 @@ jobs:
         with:
           toolchain: stable
           target: ${{ matrix.target.triple }}
-          override: true
       - name: "Run prepare tests"
         run: ci/prepare-tests.sh
       - run: |
@@ -163,7 +162,6 @@ jobs:
         with:
           toolchain: stable
           target: ${{ matrix.target.triple }}
-          override: true
       - name: "Run prepare tests"
         run: ci/prepare-tests.sh
       - run: |
@@ -246,12 +244,12 @@ jobs:
     steps:
       - name: "Download Package (DEB)"
         if: ${{ !startsWith(matrix.target.name, 'CentOS') }}
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: pica_${{ needs.version.outputs.VERSION }}-glibc${{ matrix.target.glibc}}-1_amd64.deb
       - name: "Download Package (RPM)"
         if: ${{ startsWith(matrix.target.name, 'CentOS') }}
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: pica-${{ needs.version.outputs.VERSION }}-glibc${{ matrix.target.glibc }}-1.x86_64.rpm
       - name: Fix CentoOS8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           tar cfvz "$staging.tar.gz" "$staging/"
           echo "filename=$staging.tar.gz" >> $GITHUB_OUTPUT
           echo "ASSET_PATH=$staging.tar.gz" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ASSET_PATH }}
           path: ${{ env.ASSET_PATH }}
@@ -134,7 +134,7 @@ jobs:
           cp "target/release/pica-lint.exe" "$staging/"
           7z a "$staging.zip" "$staging/"
           echo "ASSET_PATH=$staging.zip" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ASSET_PATH }}
           path: ${{ env.ASSET_PATH }}
@@ -183,7 +183,7 @@ jobs:
           cp "target/release/pica" "$staging/"
           tar cfvz "$staging.tar.gz" "$staging/"
           echo "ASSET_PATH=$staging.tar.gz" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ASSET_PATH }}
           path: ${{ env.ASSET_PATH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ on:
     - 'v*'
 
 env:
-  # RUSTFLAGS: -D warnings -W unreachable-pub -W rust-2021-compatibility
-  RUSTFLAGS: -D warnings -W rust-2021-compatibility
+  RUSTFLAGS: -D warnings -W unreachable-pub -W rust-2021-compatibility
   RUSTUP_MAX_RETRIES: 10
   CARGO_INCREMENTAL: 0
 
@@ -42,8 +41,8 @@ jobs:
     steps:
       - name: "Print glibc version"
         run: ldd --version
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-cargo-stable-${{ matrix.target.triple }}-glibc${{ matrix.target.glibc }}-${{ hashFiles('**/Cargo.toml') }}
           path: |
@@ -61,22 +60,15 @@ jobs:
       - name: "Install packages (CentOS)"
         if: ${{ startsWith(matrix.target.image, 'centos') }}
         run: yum install gcc -y
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           target: ${{ matrix.target.triple }}
-          profile: minimal
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --workspace
       - name: "Run prepare tests"
         run: ci/prepare-tests.sh
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --workspace
+      - run: |
+          cargo build --release --workspace
+          cargo test --release --workspace
       - name: "Strip release binary"
         run: |
           # strip target/release/pica-lint
@@ -111,8 +103,8 @@ jobs:
           - { triple: x86_64-pc-windows-msvc, variant: "MSVC" }
           - { triple: x86_64-pc-windows-gnu, variant: "GNU" }
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-cargo-stable-${{ matrix.target.triple }}-${{ hashFiles('**/Cargo.toml') }}
           path: |
@@ -121,22 +113,16 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/registry/index/
             target/
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           target: ${{ matrix.target.triple }}
-          profile: minimal
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --workspace
       - name: "Run prepare tests"
         run: ci/prepare-tests.sh
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --workspace
+      - run: |
+          cargo build --release --workspace
+          cargo test --release --workspace
       - name: "Build release archive"
         id: build-archive
         shell: bash
@@ -163,8 +149,8 @@ jobs:
         target:
           - { triple: x86_64-apple-darwin }
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-cargo-stable-${{ matrix.target.triple }}-${{ hashFiles('**/Cargo.toml') }}
           path: |
@@ -173,23 +159,16 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/registry/index/
             target/
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           target: ${{ matrix.target.triple }}
-          profile: minimal
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --workspace
       - name: "Run prepare tests"
         run: ci/prepare-tests.sh
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --workspace
+      - run: |
+          cargo build --release --workspace
+          cargo test --release --workspace
       - name: "Strip release binary"
         run: |
           strip target/release/pica-lint
@@ -226,9 +205,9 @@ jobs:
           - { triple: x86_64-unknown-linux-gnu, glibc: 2.35, format: deb }
           - { triple: x86_64-unknown-linux-gnu, glibc: 2.35, format: rpm }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download binary release
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: pica-${{ needs.version.outputs.VERSION }}-${{ matrix.target.triple }}-glibc${{ matrix.target.glibc }}.tar.gz
       - name: Extract binary release
@@ -243,7 +222,7 @@ jobs:
           arch: x86_64
           format: ${{ matrix.target.format }}
           package: .github/actions-rs/package.yaml
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.build_rpm.outputs.package }}
           path: ${{ steps.build_rpm.outputs.package }}
@@ -305,7 +284,7 @@ jobs:
       - version
     steps:
       - name: "Download releases/packages"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Assemble data
         run: |
           mkdir uploads/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           - { image: "ubuntu:22.04", triple: x86_64-unknown-linux-gnu, glibc: 2.35 }
           - { image: "ubuntu:20.04", triple: x86_64-unknown-linux-gnu, glibc: 2.31 }
           - { image: "debian:10", triple: x86_64-unknown-linux-gnu, glibc: 2.28 }
-          - { image: "centos:centos7", triple: x86_64-unknown-linux-gnu, glibc: 2.17 }
+          # - { image: "centos:centos7", triple: x86_64-unknown-linux-gnu, glibc: 2.17 }
     container:
       image: ${{ matrix.target.image }}
     steps:
@@ -196,8 +196,8 @@ jobs:
     strategy:
       matrix:
         target:
-          - { triple: x86_64-unknown-linux-gnu, glibc: 2.17, format: deb }
-          - { triple: x86_64-unknown-linux-gnu, glibc: 2.17, format: rpm }
+          # - { triple: x86_64-unknown-linux-gnu, glibc: 2.17, format: deb }
+          # - { triple: x86_64-unknown-linux-gnu, glibc: 2.17, format: rpm }
           - { triple: x86_64-unknown-linux-gnu, glibc: 2.28, format: deb }
           - { triple: x86_64-unknown-linux-gnu, glibc: 2.28, format: rpm }
           - { triple: x86_64-unknown-linux-gnu, glibc: 2.31, format: deb }
@@ -241,7 +241,7 @@ jobs:
           - { name: "Ubuntu 22.04", image: "ubuntu:22.04", glibc: 2.35 }
           - { name: "Ubuntu 21.10", image: "ubuntu:21.10", glibc: 2.35 }
           - { name: "Ubuntu 20.04", image: "ubuntu:20.04", glibc: 2.31 }
-          - { name: "CentOS 7", image: "centos:7", glibc: 2.17 }
+          # - { name: "CentOS 7", image: "centos:7", glibc: 2.17 }
           - { name: "CentOS 8", image: "centos:8", glibc: 2.28 }
     steps:
       - name: "Download Package (DEB)"

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,8 @@ CARGO ?= cargo
 
 .PHONY: check
 check:
-	$(CARGO) check --workspace
+	$(CARGO) check --workspace --all-features
+
+.PHONY: test
+test:
+	$(CARGO) test --workspace --all-features --no-fail-fast

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+CARGO ?= cargo
+
+.PHONY: check
+check:
+	$(CARGO) check --workspace

--- a/docs/book/src/anleitungen/installation.md
+++ b/docs/book/src/anleitungen/installation.md
@@ -25,11 +25,6 @@ Download bereit. Diese können mit folgendem Kommando installiert werden:
 $ rpm -i pica-0.20.0-glibc2.35-1.x86_64.rpm
 ```
 
-Für altere Distributionen (bspw. CentOS 7) stehen spezielle `RPM`-Pakete
-bereit, die eine ältere Version der
-[GNU C Library (glibc)](https://www.gnu.org/software/libc) verwenden
-(`2.17` und `2.31`).
-
 ## Binary-Releases
 
 Für die Betriebssysteme Linux, macOS und Windows stehen mit jeder neuen Version Binaries zum


### PR DESCRIPTION
This PR fixes GitHub deprecation warnings emitted by GitHub actions. Furthermore, the support for CentOS7 will be stopped.