### PR TITLE
Remove `$`-notation in a field matcher expression

### DIFF
--- a/crates/pica-matcher/src/field_matcher.rs
+++ b/crates/pica-matcher/src/field_matcher.rs
@@ -160,13 +160,7 @@ fn parse_subfields_matcher_dot(
     (
         parse_tag_matcher,
         parse_occurrence_matcher,
-        preceded(
-            alt((
-                '.',
-                ws('$'), // FIXME: remove legacy snytax
-            )),
-            parse_subfield_singleton_matcher,
-        ),
+        preceded('.', parse_subfield_singleton_matcher),
     )
         .map(|(t, o, s)| SubfieldsMatcher {
             tag_matcher: t,


### PR DESCRIPTION
This PR removes the support of the `$`-noation in a field-matcher expression. Instead of `'002@ $0 == "Olfo"'` use `'002@.0 == "Olfo"'`.