### PR TITLE
Add subfield wildcard in path expressions

### DIFF
--- a/crates/pica-toolkit/tests/snapshot/select/048-select-subfield-wildcard.toml
+++ b/crates/pica-toolkit/tests/snapshot/select/048-select-subfield-wildcard.toml
@@ -1,0 +1,6 @@
+bin.name = "pica"
+args = "select '012A.*'"
+status = "success"
+stdin = "012A \u001fa123\u001fa456\u001e\n"
+stdout = "123\n456\n"
+stderr = ""


### PR DESCRIPTION
This PR introduce the subfield wildcard `*` in a path expression. 

Example Record:

```console
$ pica filter --keep '046G' '003@?' record.dat | pica print
046G $a Mitwirkung bei: Deutsches Schaffen und Ringen im Ausland $b ein Quellenlesebuch für [...] $f 1916
046G $a Hg. v. Leitfaden der deutschsprachigen Presse im Ausland $f 1984
````

The following commands lump all subfields of the field `045G` together, which will be written to the second column:
```console
$ pica select '003@.0, 045G.*' record.dat
00010244X,Mitwirkung bei: Deutsches Schaffen und Ringen im Ausland
00010244X,"ein Quellenlesebuch für Jugend und Volk, für Schule und Haus"
00010244X,1916
00010244X,Hg. v. Leitfaden der deutschsprachigen Presse im Ausland
00010244X,1984
```

This can be useful in combination with the  `--squash` option to count the occurrences of a field:

```console
$ pica select --squash '003@.0, 046G.*' record.dat
00010244X,"Mitwirkung bei: Deutsches Schaffen und Ringen im Ausland|ein Quellenlesebuch für [...]|1916"
00010244X,Hg. v. Leitfaden der deutschsprachigen Presse im Ausland|1984
```

```console
$ pica select --squash '003@.0, 046G.*' record.dat | cut -d',' -f1
00010244X,
00010244X,
```