### PR TITLE
Allow subfield code ranges in subfield matcher

### DIFF
--- a/crates/pica-toolkit/tests/snapshot/filter/0301-filter-subfield-wildcard.stdin
+++ b/crates/pica-toolkit/tests/snapshot/filter/0301-filter-subfield-wildcard.stdin
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/crates/pica-toolkit/tests/snapshot/filter/0301-filter-subfield-wildcard.stdout
+++ b/crates/pica-toolkit/tests/snapshot/filter/0301-filter-subfield-wildcard.stdout
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/crates/pica-toolkit/tests/snapshot/filter/0301-filter-subfield-wildcard.toml
+++ b/crates/pica-toolkit/tests/snapshot/filter/0301-filter-subfield-wildcard.toml
@@ -1,0 +1,4 @@
+bin.name = "pica"
+args = "filter '041[A@].* =? \"Algebra\"'"
+status = "success"
+stderr = ""


### PR DESCRIPTION
This PR introduce subfield code ranges in a matcher/filter expression. The following expression searches for the substring 'Algebra' in any subfields of the fields `041A` oder `041@`:

```console
$ pica filter '041[A@].[a-z] =? "Algebra"' algebra.dat
```

NB: Now, a path and a matcher expression use the same syntax (single code, ranges, wildcards).