### PR TITLE
Add existential and universal quantifier

### DIFF
--- a/crates/pica-matcher/src/common.rs
+++ b/crates/pica-matcher/src/common.rs
@@ -132,18 +132,18 @@ pub(crate) fn parse_relational_op_usize(
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum Quantifier {
-    All,
+    Forall,
     #[default]
-    Any,
+    Exists,
 }
 
 #[inline]
 pub(crate) fn parse_quantifier(i: &mut &[u8]) -> PResult<Quantifier> {
     alt((
-        "ALL".value(Quantifier::All),
-        "∀".value(Quantifier::All),
-        "ANY".value(Quantifier::Any),
-        "∃".value(Quantifier::Any),
+        "∀".value(Quantifier::Forall),
+        "ForAll".value(Quantifier::Forall),
+        "∃".value(Quantifier::Exists),
+        "Exists".value(Quantifier::Exists),
     ))
     .parse_next(i)
 }

--- a/crates/pica-matcher/src/common.rs
+++ b/crates/pica-matcher/src/common.rs
@@ -1,7 +1,9 @@
 use std::fmt::{self, Display};
 
 use winnow::ascii::{multispace0, multispace1};
-use winnow::combinator::{alt, delimited, fold_repeat, preceded};
+use winnow::combinator::{
+    alt, delimited, fold_repeat, preceded, terminated,
+};
 use winnow::error::{ContextError, ParserError};
 use winnow::stream::{AsChar, Stream, StreamIsPartial};
 use winnow::token::{tag, take_till};
@@ -132,18 +134,18 @@ pub(crate) fn parse_relational_op_usize(
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum Quantifier {
-    Forall,
+    All,
     #[default]
-    Exists,
+    Any,
 }
 
 #[inline]
 pub(crate) fn parse_quantifier(i: &mut &[u8]) -> PResult<Quantifier> {
     alt((
-        "∀".value(Quantifier::Forall),
-        "ForAll".value(Quantifier::Forall),
-        "∃".value(Quantifier::Exists),
-        "Exists".value(Quantifier::Exists),
+        terminated("ALL".value(Quantifier::All), multispace1),
+        terminated("ANY".value(Quantifier::Any), multispace1),
+        "∀".value(Quantifier::All),
+        "∃".value(Quantifier::Any),
     ))
     .parse_next(i)
 }

--- a/crates/pica-matcher/src/common.rs
+++ b/crates/pica-matcher/src/common.rs
@@ -130,6 +130,24 @@ pub(crate) fn parse_relational_op_usize(
     .parse_next(i)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum Quantifier {
+    All,
+    #[default]
+    Any,
+}
+
+#[inline]
+pub(crate) fn parse_quantifier(i: &mut &[u8]) -> PResult<Quantifier> {
+    alt((
+        "ALL".value(Quantifier::All),
+        "∀".value(Quantifier::All),
+        "ANY".value(Quantifier::Any),
+        "∃".value(Quantifier::Any),
+    ))
+    .parse_next(i)
+}
+
 #[derive(Debug, Copy, Clone)]
 enum Quotes {
     Single,

--- a/crates/pica-matcher/src/field_matcher.rs
+++ b/crates/pica-matcher/src/field_matcher.rs
@@ -169,8 +169,8 @@ impl SubfieldsMatcher {
         };
 
         match self.quantifier {
-            Quantifier::Forall => fields.all(check_fn),
-            Quantifier::Exists => fields.any(check_fn),
+            Quantifier::All => fields.all(check_fn),
+            Quantifier::Any => fields.any(check_fn),
         }
     }
 }

--- a/crates/pica-matcher/src/field_matcher.rs
+++ b/crates/pica-matcher/src/field_matcher.rs
@@ -14,7 +14,8 @@ use winnow::error::ParserError;
 use winnow::prelude::*;
 
 use crate::common::{
-    parse_relational_op_usize, ws, BooleanOp, RelationalOp,
+    parse_quantifier, parse_relational_op_usize, ws, BooleanOp,
+    RelationalOp,
 };
 use crate::occurrence_matcher::parse_occurrence_matcher;
 use crate::subfield_matcher::{
@@ -22,7 +23,7 @@ use crate::subfield_matcher::{
 };
 use crate::tag_matcher::parse_tag_matcher;
 use crate::{
-    MatcherOptions, OccurrenceMatcher, ParseMatcherError,
+    MatcherOptions, OccurrenceMatcher, ParseMatcherError, Quantifier,
     SubfieldMatcher, TagMatcher,
 };
 
@@ -113,6 +114,7 @@ impl FromStr for ExistsMatcher {
 /// criterion.
 #[derive(Debug, Clone)]
 pub struct SubfieldsMatcher {
+    quantifier: Quantifier,
     tag_matcher: TagMatcher,
     occurrence_matcher: OccurrenceMatcher,
     subfield_matcher: SubfieldMatcher,
@@ -157,13 +159,19 @@ impl SubfieldsMatcher {
         fields: impl IntoIterator<Item = &'a FieldRef<'a>>,
         options: &MatcherOptions,
     ) -> bool {
-        fields.into_iter().any(|field| {
+        let mut fields = fields.into_iter().filter(|field| {
             self.tag_matcher == field.tag()
                 && self.occurrence_matcher == field.occurrence()
-                && self
-                    .subfield_matcher
-                    .is_match(field.subfields(), options)
-        })
+        });
+
+        let check_fn = |field: &FieldRef| -> bool {
+            self.subfield_matcher.is_match(field.subfields(), options)
+        };
+
+        match self.quantifier {
+            Quantifier::Any => fields.any(check_fn),
+            Quantifier::All => fields.all(check_fn),
+        }
     }
 }
 
@@ -171,11 +179,13 @@ fn parse_subfields_matcher_dot(
     i: &mut &[u8],
 ) -> PResult<SubfieldsMatcher> {
     (
+        opt(ws(parse_quantifier)).map(Option::unwrap_or_default),
         parse_tag_matcher,
         parse_occurrence_matcher,
         preceded('.', parse_subfield_singleton_matcher),
     )
-        .map(|(t, o, s)| SubfieldsMatcher {
+        .map(|(q, t, o, s)| SubfieldsMatcher {
+            quantifier: q,
             tag_matcher: t,
             occurrence_matcher: o,
             subfield_matcher: s,
@@ -187,11 +197,13 @@ fn parse_subfields_matcher_bracket(
     i: &mut &[u8],
 ) -> PResult<SubfieldsMatcher> {
     (
+        opt(ws(parse_quantifier)).map(Option::unwrap_or_default),
         parse_tag_matcher,
         parse_occurrence_matcher,
         delimited(ws('{'), parse_subfield_matcher, ws('}')),
     )
-        .map(|(t, o, s)| SubfieldsMatcher {
+        .map(|(q, t, o, s)| SubfieldsMatcher {
+            quantifier: q,
             tag_matcher: t,
             occurrence_matcher: o,
             subfield_matcher: s,
@@ -523,13 +535,15 @@ fn parse_field_matcher_exists(i: &mut &[u8]) -> PResult<FieldMatcher> {
             FieldMatcher::Singleton(SingletonMatcher::Exists(matcher))
         }),
         (
+            opt(parse_quantifier).map(Option::unwrap_or_default),
             parse_tag_matcher,
             parse_occurrence_matcher,
             preceded(ws('.'), subfield_matcher::parse_exists_matcher),
         )
-            .map(|(t, o, s)| {
+            .map(|(q, t, o, s)| {
                 FieldMatcher::Singleton(SingletonMatcher::Subfields(
                     SubfieldsMatcher {
+                        quantifier: q,
                         tag_matcher: t,
                         occurrence_matcher: o,
                         subfield_matcher: SubfieldMatcher::Singleton(

--- a/crates/pica-matcher/src/field_matcher.rs
+++ b/crates/pica-matcher/src/field_matcher.rs
@@ -169,8 +169,8 @@ impl SubfieldsMatcher {
         };
 
         match self.quantifier {
-            Quantifier::Any => fields.any(check_fn),
-            Quantifier::All => fields.all(check_fn),
+            Quantifier::Forall => fields.all(check_fn),
+            Quantifier::Exists => fields.any(check_fn),
         }
     }
 }

--- a/crates/pica-matcher/src/lib.rs
+++ b/crates/pica-matcher/src/lib.rs
@@ -11,7 +11,7 @@ mod record_matcher;
 pub mod subfield_matcher;
 mod tag_matcher;
 
-pub use common::RelationalOp;
+pub use common::{Quantifier, RelationalOp};
 pub use error::ParseMatcherError;
 pub use field_matcher::FieldMatcher;
 pub use matcher_builder::MatcherBuilder;

--- a/crates/pica-matcher/src/subfield_matcher.rs
+++ b/crates/pica-matcher/src/subfield_matcher.rs
@@ -354,7 +354,7 @@ impl RelationMatcher {
 #[inline]
 fn parse_relation_matcher(i: &mut &[u8]) -> PResult<RelationMatcher> {
     (
-        opt(ws(parse_quantifier)).map(|q| q.unwrap_or_default()),
+        opt(ws(parse_quantifier)).map(Option::unwrap_or_default),
         ws(parse_subfield_codes),
         ws(parse_relational_op_str),
         ws(parse_string),
@@ -484,7 +484,7 @@ impl RegexMatcher {
 /// Parse a regex matcher expression
 fn parse_regex_matcher(i: &mut &[u8]) -> PResult<RegexMatcher> {
     (
-        opt(ws(parse_quantifier)).map(|q| q.unwrap_or_default()),
+        opt(ws(parse_quantifier)).map(Option::unwrap_or_default),
         ws(parse_subfield_codes),
         ws(alt(("=~".value(false), "!~".value(true)))),
         parse_string
@@ -633,7 +633,7 @@ impl InMatcher {
 /// Parse a in matcher expression.
 fn parse_in_matcher(i: &mut &[u8]) -> PResult<InMatcher> {
     (
-        opt(ws(parse_quantifier)).map(|s| s.unwrap_or_default()),
+        opt(ws(parse_quantifier)).map(Option::unwrap_or_default),
         ws(parse_subfield_codes),
         opt(ws("not")).map(|x| x.is_some()),
         preceded(

--- a/crates/pica-matcher/src/subfield_matcher.rs
+++ b/crates/pica-matcher/src/subfield_matcher.rs
@@ -254,8 +254,8 @@ impl RelationMatcher {
         };
 
         match self.quantifier {
-            Quantifier::Any => subfields.any(check),
-            Quantifier::All => subfields.all(check),
+            Quantifier::Forall => subfields.all(check),
+            Quantifier::Exists => subfields.any(check),
         }
     }
 
@@ -413,13 +413,21 @@ impl RegexMatcher {
     ///     let options = Default::default();
     ///
     ///     let subfield = SubfieldRef::new('0', "Oa");
-    ///     let matcher =
-    ///         RegexMatcher::new(vec!['0'], "^Oa", Quantifier::Any, false);
+    ///     let matcher = RegexMatcher::new(
+    ///         vec!['0'],
+    ///         "^Oa",
+    ///         Quantifier::Exists,
+    ///         false,
+    ///     );
     ///     assert!(matcher.is_match(&subfield, &options));
     ///
     ///     let subfield = SubfieldRef::new('0', "Ob");
-    ///     let matcher =
-    ///         RegexMatcher::new(vec!['0'], "^Oa", Quantifier::Any, true);
+    ///     let matcher = RegexMatcher::new(
+    ///         vec!['0'],
+    ///         "^Oa",
+    ///         Quantifier::Exists,
+    ///         true,
+    ///     );
     ///     assert!(matcher.is_match(&subfield, &options));
     ///
     ///     Ok(())
@@ -475,8 +483,8 @@ impl RegexMatcher {
         };
 
         match self.quantifier {
-            Quantifier::Any => subfields.any(check_fn),
-            Quantifier::All => subfields.all(check_fn),
+            Quantifier::Forall => subfields.all(check_fn),
+            Quantifier::Exists => subfields.any(check_fn),
         }
     }
 }
@@ -545,7 +553,7 @@ impl InMatcher {
     ///     let matcher = InMatcher::new(
     ///         vec!['0'],
     ///         vec!["abc", "def"],
-    ///         Quantifier::Any,
+    ///         Quantifier::Exists,
     ///         false,
     ///     );
     ///     let options = Default::default();
@@ -556,7 +564,7 @@ impl InMatcher {
     ///     let matcher = InMatcher::new(
     ///         vec!['0'],
     ///         vec!["abc", "def"],
-    ///         Quantifier::Any,
+    ///         Quantifier::Exists,
     ///         true,
     ///     );
     ///     let options = Default::default();
@@ -624,8 +632,8 @@ impl InMatcher {
         };
 
         match self.quantifier {
-            Quantifier::Any => subfields.any(check_fn),
-            Quantifier::All => subfields.all(check_fn),
+            Quantifier::Forall => subfields.all(check_fn),
+            Quantifier::Exists => subfields.any(check_fn),
         }
     }
 }
@@ -686,7 +694,7 @@ impl CardinalityMatcher {
     ///
     /// # Panics
     ///
-    /// This function panics on any invalid input. The cardinality
+    /// This function panics on ∀ invalid input. The cardinality
     /// matcher uses only a subset of all relational operators; the
     /// caller must ensure that the operator is applicable on
     /// `usize`.
@@ -1198,118 +1206,46 @@ mod tests {
             };
         }
 
-        parse_success!(b"0 == 'abc'", Any, vec!['0'], Eq, b"abc");
-        parse_success!(b"0 != 'abc'", Any, vec!['0'], Ne, b"abc");
+        parse_success!(b"0 == 'abc'", Exists, vec!['0'], Eq, b"abc");
+        parse_success!(b"0 != 'abc'", Exists, vec!['0'], Ne, b"abc");
         parse_success!(
             b"0 =^ 'abc'",
-            Any,
+            Exists,
             vec!['0'],
             StartsWith,
             b"abc"
         );
         parse_success!(
             b"0 !^ 'abc'",
-            Any,
+            Exists,
             vec!['0'],
             StartsNotWith,
             b"abc"
         );
-        parse_success!(b"0 =$ 'abc'", Any, vec!['0'], EndsWith, b"abc");
+        parse_success!(
+            b"0 =$ 'abc'",
+            Exists,
+            vec!['0'],
+            EndsWith,
+            b"abc"
+        );
         parse_success!(
             b"0 !$ 'abc'",
-            Any,
-            vec!['0'],
-            EndsNotWith,
-            b"abc"
-        );
-        parse_success!(b"0 =* 'abc'", Any, vec!['0'], Similar, b"abc");
-        parse_success!(b"0 =? 'abc'", Any, vec!['0'], Contains, b"abc");
-
-        parse_success!(b"ANY 0 == 'abc'", Any, vec!['0'], Eq, b"abc");
-        parse_success!(b"ANY 0 != 'abc'", Any, vec!['0'], Ne, b"abc");
-        parse_success!(
-            b"ANY 0 =^ 'abc'",
-            Any,
-            vec!['0'],
-            StartsWith,
-            b"abc"
-        );
-        parse_success!(
-            b"ANY 0 !^ 'abc'",
-            Any,
-            vec!['0'],
-            StartsNotWith,
-            b"abc"
-        );
-        parse_success!(
-            b"ANY 0 =$ 'abc'",
-            Any,
-            vec!['0'],
-            EndsWith,
-            b"abc"
-        );
-        parse_success!(
-            b"ANY 0 !$ 'abc'",
-            Any,
+            Exists,
             vec!['0'],
             EndsNotWith,
             b"abc"
         );
         parse_success!(
-            b"ANY 0 =* 'abc'",
-            Any,
+            b"0 =* 'abc'",
+            Exists,
             vec!['0'],
             Similar,
             b"abc"
         );
         parse_success!(
-            b"ANY 0 =? 'abc'",
-            Any,
-            vec!['0'],
-            Contains,
-            b"abc"
-        );
-
-        parse_success!(b"ALL 0 == 'abc'", All, vec!['0'], Eq, b"abc");
-        parse_success!(b"ALL 0 != 'abc'", All, vec!['0'], Ne, b"abc");
-        parse_success!(
-            b"ALL 0 =^ 'abc'",
-            All,
-            vec!['0'],
-            StartsWith,
-            b"abc"
-        );
-        parse_success!(
-            b"ALL 0 !^ 'abc'",
-            All,
-            vec!['0'],
-            StartsNotWith,
-            b"abc"
-        );
-        parse_success!(
-            b"ALL 0 =$ 'abc'",
-            All,
-            vec!['0'],
-            EndsWith,
-            b"abc"
-        );
-        parse_success!(
-            b"ALL 0 !$ 'abc'",
-            All,
-            vec!['0'],
-            EndsNotWith,
-            b"abc"
-        );
-        parse_success!(
-            b"ALL 0 =* 'abc'",
-            All,
-            vec!['0'],
-            Similar,
-            b"abc"
-        );
-        parse_success!(
-            b"ALL 0 =? 'abc'",
-            All,
+            b"0 =? 'abc'",
+            Exists,
             vec!['0'],
             Contains,
             b"abc"
@@ -1330,7 +1266,7 @@ mod tests {
                 assert_eq!(
                     parse_regex_matcher.parse($input).unwrap(),
                     RegexMatcher {
-                        quantifier: Quantifier::Any,
+                        quantifier: Quantifier::Exists,
                         codes: $codes,
                         invert: $invert,
                         re: $re.to_string()

--- a/crates/pica-matcher/src/subfield_matcher.rs
+++ b/crates/pica-matcher/src/subfield_matcher.rs
@@ -254,8 +254,8 @@ impl RelationMatcher {
         };
 
         match self.quantifier {
-            Quantifier::Forall => subfields.all(check),
-            Quantifier::Exists => subfields.any(check),
+            Quantifier::All => subfields.all(check),
+            Quantifier::Any => subfields.any(check),
         }
     }
 
@@ -413,21 +413,13 @@ impl RegexMatcher {
     ///     let options = Default::default();
     ///
     ///     let subfield = SubfieldRef::new('0', "Oa");
-    ///     let matcher = RegexMatcher::new(
-    ///         vec!['0'],
-    ///         "^Oa",
-    ///         Quantifier::Exists,
-    ///         false,
-    ///     );
+    ///     let matcher =
+    ///         RegexMatcher::new(vec!['0'], "^Oa", Quantifier::Any, false);
     ///     assert!(matcher.is_match(&subfield, &options));
     ///
     ///     let subfield = SubfieldRef::new('0', "Ob");
-    ///     let matcher = RegexMatcher::new(
-    ///         vec!['0'],
-    ///         "^Oa",
-    ///         Quantifier::Exists,
-    ///         true,
-    ///     );
+    ///     let matcher =
+    ///         RegexMatcher::new(vec!['0'], "^Oa", Quantifier::Any, true);
     ///     assert!(matcher.is_match(&subfield, &options));
     ///
     ///     Ok(())
@@ -483,8 +475,8 @@ impl RegexMatcher {
         };
 
         match self.quantifier {
-            Quantifier::Forall => subfields.all(check_fn),
-            Quantifier::Exists => subfields.any(check_fn),
+            Quantifier::All => subfields.all(check_fn),
+            Quantifier::Any => subfields.any(check_fn),
         }
     }
 }
@@ -553,7 +545,7 @@ impl InMatcher {
     ///     let matcher = InMatcher::new(
     ///         vec!['0'],
     ///         vec!["abc", "def"],
-    ///         Quantifier::Exists,
+    ///         Quantifier::Any,
     ///         false,
     ///     );
     ///     let options = Default::default();
@@ -564,7 +556,7 @@ impl InMatcher {
     ///     let matcher = InMatcher::new(
     ///         vec!['0'],
     ///         vec!["abc", "def"],
-    ///         Quantifier::Exists,
+    ///         Quantifier::Any,
     ///         true,
     ///     );
     ///     let options = Default::default();
@@ -632,8 +624,8 @@ impl InMatcher {
         };
 
         match self.quantifier {
-            Quantifier::Forall => subfields.all(check_fn),
-            Quantifier::Exists => subfields.any(check_fn),
+            Quantifier::All => subfields.all(check_fn),
+            Quantifier::Any => subfields.any(check_fn),
         }
     }
 }
@@ -1206,50 +1198,32 @@ mod tests {
             };
         }
 
-        parse_success!(b"0 == 'abc'", Exists, vec!['0'], Eq, b"abc");
-        parse_success!(b"0 != 'abc'", Exists, vec!['0'], Ne, b"abc");
+        parse_success!(b"0 == 'abc'", Any, vec!['0'], Eq, b"abc");
+        parse_success!(b"0 != 'abc'", Any, vec!['0'], Ne, b"abc");
         parse_success!(
             b"0 =^ 'abc'",
-            Exists,
+            Any,
             vec!['0'],
             StartsWith,
             b"abc"
         );
         parse_success!(
             b"0 !^ 'abc'",
-            Exists,
+            Any,
             vec!['0'],
             StartsNotWith,
             b"abc"
         );
-        parse_success!(
-            b"0 =$ 'abc'",
-            Exists,
-            vec!['0'],
-            EndsWith,
-            b"abc"
-        );
+        parse_success!(b"0 =$ 'abc'", Any, vec!['0'], EndsWith, b"abc");
         parse_success!(
             b"0 !$ 'abc'",
-            Exists,
+            Any,
             vec!['0'],
             EndsNotWith,
             b"abc"
         );
-        parse_success!(
-            b"0 =* 'abc'",
-            Exists,
-            vec!['0'],
-            Similar,
-            b"abc"
-        );
-        parse_success!(
-            b"0 =? 'abc'",
-            Exists,
-            vec!['0'],
-            Contains,
-            b"abc"
-        );
+        parse_success!(b"0 =* 'abc'", Any, vec!['0'], Similar, b"abc");
+        parse_success!(b"0 =? 'abc'", Any, vec!['0'], Contains, b"abc");
 
         assert!(parse_relation_matcher.parse(b"0 >= 'abc'").is_err());
         assert!(parse_relation_matcher.parse(b"0 > 'abc'").is_err());
@@ -1266,7 +1240,7 @@ mod tests {
                 assert_eq!(
                     parse_regex_matcher.parse($input).unwrap(),
                     RegexMatcher {
-                        quantifier: Quantifier::Exists,
+                        quantifier: Quantifier::Any,
                         codes: $codes,
                         invert: $invert,
                         re: $re.to_string()

--- a/crates/pica-matcher/tests/subfield_matcher/mod.rs
+++ b/crates/pica-matcher/tests/subfield_matcher/mod.rs
@@ -352,7 +352,7 @@ fn regex_matcher_new() {
     let _ = RegexMatcher::new(
         vec!['0'],
         "^T[gpsu][1z]$",
-        Quantifier::All,
+        Quantifier::Forall,
         false,
     );
 }
@@ -363,7 +363,7 @@ fn regex_matcher_new_panic1() {
     RegexMatcher::new(
         vec!['0'],
         "^T[[gpsu][1z]$",
-        Quantifier::Any,
+        Quantifier::Exists,
         false,
     );
 }
@@ -435,7 +435,7 @@ fn in_matcher_new() {
     assert!(InMatcher::new(
         vec!['0'],
         vec!["abc", "def"],
-        Quantifier::All,
+        Quantifier::Forall,
         false
     )
     .is_match(&subfield!('0', "abc"), &MatcherOptions::default()));
@@ -447,7 +447,7 @@ fn in_matcher_new_panic() {
     let _ = InMatcher::new(
         vec!['!'],
         vec!["abc", "def"],
-        Quantifier::Any,
+        Quantifier::Exists,
         false,
     );
 }

--- a/crates/pica-matcher/tests/subfield_matcher/mod.rs
+++ b/crates/pica-matcher/tests/subfield_matcher/mod.rs
@@ -2,7 +2,9 @@ use std::str::FromStr;
 
 use bstr::B;
 use pica_matcher::subfield_matcher::*;
-use pica_matcher::{MatcherOptions, ParseMatcherError, RelationalOp};
+use pica_matcher::{
+    MatcherOptions, ParseMatcherError, Quantifier, RelationalOp,
+};
 use pica_record::SubfieldRef;
 
 use crate::TestResult;
@@ -347,13 +349,23 @@ fn relational_matcher_contains() {
 
 #[test]
 fn regex_matcher_new() {
-    let _ = RegexMatcher::new(vec!['0'], "^T[gpsu][1z]$", false);
+    let _ = RegexMatcher::new(
+        vec!['0'],
+        "^T[gpsu][1z]$",
+        Quantifier::All,
+        false,
+    );
 }
 
 #[test]
 #[should_panic]
 fn regex_matcher_new_panic1() {
-    RegexMatcher::new(vec!['0'], "^T[[gpsu][1z]$", false);
+    RegexMatcher::new(
+        vec!['0'],
+        "^T[[gpsu][1z]$",
+        Quantifier::Any,
+        false,
+    );
 }
 
 #[test]
@@ -420,14 +432,24 @@ fn regex_matcher_is_match() -> TestResult {
 
 #[test]
 fn in_matcher_new() {
-    assert!(InMatcher::new(vec!['0'], vec!["abc", "def"], false)
-        .is_match(&subfield!('0', "abc"), &MatcherOptions::default()));
+    assert!(InMatcher::new(
+        vec!['0'],
+        vec!["abc", "def"],
+        Quantifier::All,
+        false
+    )
+    .is_match(&subfield!('0', "abc"), &MatcherOptions::default()));
 }
 
 #[test]
 #[should_panic]
 fn in_matcher_new_panic() {
-    let _ = InMatcher::new(vec!['!'], vec!["abc", "def"], false);
+    let _ = InMatcher::new(
+        vec!['!'],
+        vec!["abc", "def"],
+        Quantifier::Any,
+        false,
+    );
 }
 
 #[test]

--- a/crates/pica-matcher/tests/subfield_matcher/mod.rs
+++ b/crates/pica-matcher/tests/subfield_matcher/mod.rs
@@ -352,7 +352,7 @@ fn regex_matcher_new() {
     let _ = RegexMatcher::new(
         vec!['0'],
         "^T[gpsu][1z]$",
-        Quantifier::Forall,
+        Quantifier::All,
         false,
     );
 }
@@ -363,7 +363,7 @@ fn regex_matcher_new_panic1() {
     RegexMatcher::new(
         vec!['0'],
         "^T[[gpsu][1z]$",
-        Quantifier::Exists,
+        Quantifier::Any,
         false,
     );
 }
@@ -435,7 +435,7 @@ fn in_matcher_new() {
     assert!(InMatcher::new(
         vec!['0'],
         vec!["abc", "def"],
-        Quantifier::Forall,
+        Quantifier::All,
         false
     )
     .is_match(&subfield!('0', "abc"), &MatcherOptions::default()));
@@ -447,7 +447,7 @@ fn in_matcher_new_panic() {
     let _ = InMatcher::new(
         vec!['!'],
         vec!["abc", "def"],
-        Quantifier::Exists,
+        Quantifier::Any,
         false,
     );
 }

--- a/crates/pica-toolkit/tests/snapshot/filter/0302-filter-field-all-quantifier.stdin
+++ b/crates/pica-toolkit/tests/snapshot/filter/0302-filter-field-all-quantifier.stdin
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/crates/pica-toolkit/tests/snapshot/filter/0302-filter-field-all-quantifier.toml
+++ b/crates/pica-toolkit/tests/snapshot/filter/0302-filter-field-all-quantifier.toml
@@ -1,0 +1,5 @@
+bin.name = "pica"
+args = "filter 'ALL 041[@AP].a =? \"Algebra\"'"
+status = "success"
+stderr = ""
+stdout = ""

--- a/crates/pica-toolkit/tests/snapshot/filter/0302-filter-field-any-quantifier.stdin
+++ b/crates/pica-toolkit/tests/snapshot/filter/0302-filter-field-any-quantifier.stdin
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/crates/pica-toolkit/tests/snapshot/filter/0302-filter-field-any-quantifier.stdout
+++ b/crates/pica-toolkit/tests/snapshot/filter/0302-filter-field-any-quantifier.stdout
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/crates/pica-toolkit/tests/snapshot/filter/0302-filter-field-any-quantifier.toml
+++ b/crates/pica-toolkit/tests/snapshot/filter/0302-filter-field-any-quantifier.toml
@@ -1,0 +1,4 @@
+bin.name = "pica"
+args = "filter 'ANY 041[@AP].a =? \"Algebra\"'"
+status = "success"
+stderr = ""

--- a/crates/pica-toolkit/tests/snapshot/filter/0302-filter-subfield-all-quantifier.stdin
+++ b/crates/pica-toolkit/tests/snapshot/filter/0302-filter-subfield-all-quantifier.stdin
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/crates/pica-toolkit/tests/snapshot/filter/0302-filter-subfield-all-quantifier.toml
+++ b/crates/pica-toolkit/tests/snapshot/filter/0302-filter-subfield-all-quantifier.toml
@@ -1,0 +1,5 @@
+bin.name = "pica"
+args = "filter '008B{ ALL a == \"z\" }'"
+status = "success"
+stderr = ""
+stdout = ""

--- a/crates/pica-toolkit/tests/snapshot/filter/0302-filter-subfield-any-quantifier.stdin
+++ b/crates/pica-toolkit/tests/snapshot/filter/0302-filter-subfield-any-quantifier.stdin
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/crates/pica-toolkit/tests/snapshot/filter/0302-filter-subfield-any-quantifier.stdout
+++ b/crates/pica-toolkit/tests/snapshot/filter/0302-filter-subfield-any-quantifier.stdout
@@ -1,0 +1,1 @@
+../data/algebra.dat

--- a/crates/pica-toolkit/tests/snapshot/filter/0302-filter-subfield-any-quantifier.toml
+++ b/crates/pica-toolkit/tests/snapshot/filter/0302-filter-subfield-any-quantifier.toml
@@ -1,0 +1,4 @@
+bin.name = "pica"
+args = "filter '008B{ ANY a == \"z\" }'"
+status = "success"
+stderr = ""


### PR DESCRIPTION
This PR adds the existential and universal quantifier to a matcher expression. 

The universal quantifier (`∀`, `ALL`) requires that all fields (or subfields) must satisfy the given predicate. The following expressions matches only records, where **for all** fields `065R` the predicate (there exists a subfield `7` which is equal to `"Tg1"`) evaluates to `true`.

```console
$ pica filter -s 'ALL 065R.7 == "Tg1"' DUMP.dat.gz
$ pica filter -s '∀065R.7 == "Tg1"' DUMP.dat.gz
```

The universal quantifier can also be used in a subfield matcher expression:

```console
$ pica filter -s '010@{ ALL a == "ger" }' DUMP.dat.gz
$ pica filter -s '010@{ ∀a == "ger" }' DUMP.dat.gz
```

Because the universal quantifier evaluates to `true`, if the set of fields (or subfields) is empty, it might be necessary to and a precondition to ensure the existence of at least one element. 

```console
$ pica filter -s '010@.a? && ALL 010@.a == "ger"' DUMP.dat.gz
```

**Notes**

- By default all expressions use implicitly the existential quantifier (`∃`, `ANY`)
- The scope of a quantifier starts with the next field (or subfield) matcher and ends after this matcher.