### PR TITLE
utils: mv `FilterList` into `pica-toolkit`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,19 +120,17 @@ jobs:
           cross build --target ${{ matrix.target.triple }}
 
   fuzz:
-    # if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
-    # see https://github.com/deutsche-nationalbibliothek/pica-rs/actions/runs/7736509249/job/21094015127
-    if: false
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     name: fuzz ${{ matrix.item.name }}
     runs-on: ubuntu-latest
     needs: check
     strategy:
       matrix:
         item:
-          - { name: pica-record-ref, fuzz-dir: crates/pica-record/fuzz, target: fuzz-record-ref, max-total-time: 300 }
-          - { name: pica-record-matcher, fuzz-dir: crates/pica-matcher/fuzz, target: fuzz-record-matcher, max-total-time: 300 }
-          - { name: pica-select-query, fuzz-dir: crates/pica-select/fuzz, target: fuzz-query, max-total-time: 300 }
-          - { name: pica-path, fuzz-dir: crates/pica-path/fuzz, target: fuzz-path, max-total-time: 300 }
+          - { name: pica-record-ref, fuzz-dir: crates/pica-record/fuzz, target: fuzz-record-ref, max-total-time: 240 }
+          - { name: pica-record-matcher, fuzz-dir: crates/pica-matcher/fuzz, target: fuzz-record-matcher, max-total-time: 240 }
+          - { name: pica-select-query, fuzz-dir: crates/pica-select/fuzz, target: fuzz-query, max-total-time: 240 }
+          - { name: pica-path, fuzz-dir: crates/pica-path/fuzz, target: fuzz-path, max-total-time: 240 }
     steps:
       - uses: actions/checkout@v4
       - uses: abbbi/github-actions-tune@v1
@@ -356,7 +354,7 @@ jobs:
       - cross
       - deny
       - fmt
-      # - fuzz
+      - fuzz
       - miri
       - test
       # - udeps

--- a/crates/pica-toolkit/Cargo.toml
+++ b/crates/pica-toolkit/Cargo.toml
@@ -16,11 +16,12 @@ csv = { workspace = true }
 directories = { version = "5.0" }
 flate2 = { workspace = true }
 indicatif = { version = "0.17" }
-pica-utils = { workspace = true }
 pica-matcher = { workspace = true }
 pica-path = { workspace = true }
 pica-record = { workspace = true }
 pica-select = { workspace = true }
+pica-utils = { workspace = true }
+polars = { workspace = true }
 quick-xml = { version = "0.31" }
 rand = { workspace = true }
 regex = { workspace = true }

--- a/crates/pica-toolkit/src/commands/filter.rs
+++ b/crates/pica-toolkit/src/commands/filter.rs
@@ -10,10 +10,10 @@ use pica_matcher::{
 };
 use pica_path::PathExt;
 use pica_record::io::{ReaderBuilder, RecordsIterator, WriterBuilder};
-use pica_utils::FilterList;
 use serde::{Deserialize, Serialize};
 
 use crate::error::CliResult;
+use crate::filter_list::FilterList;
 use crate::progress::Progress;
 use crate::{gzip_flag, skip_invalid_flag, Config};
 

--- a/crates/pica-toolkit/src/commands/select.rs
+++ b/crates/pica-toolkit/src/commands/select.rs
@@ -12,11 +12,12 @@ use pica_matcher::{MatcherBuilder, MatcherOptions};
 use pica_path::PathExt;
 use pica_record::io::{ReaderBuilder, RecordsIterator};
 use pica_select::{Query, QueryExt, QueryOptions};
-use pica_utils::{FilterList, NormalizationForm};
+use pica_utils::NormalizationForm;
 use serde::{Deserialize, Serialize};
 
 use crate::config::Config;
 use crate::error::CliResult;
+use crate::filter_list::FilterList;
 use crate::progress::Progress;
 use crate::skip_invalid_flag;
 

--- a/crates/pica-toolkit/src/filter_list.rs
+++ b/crates/pica-toolkit/src/filter_list.rs
@@ -8,13 +8,13 @@ use bstr::{BStr, BString};
 use polars::prelude::*;
 
 #[derive(Debug, Default)]
-pub struct FilterList {
+pub(crate) struct FilterList {
     allow: BTreeSet<BString>,
     deny: BTreeSet<BString>,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum FilterListError {
+pub(crate) enum FilterListError {
     #[error("invalid file format (path = '{0}')")]
     InvalidFileFormat(String),
 
@@ -29,11 +29,11 @@ pub enum FilterListError {
 }
 
 impl FilterList {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
-    pub fn check(&self, idn: Option<&BStr>) -> bool {
+    pub(crate) fn check(&self, idn: Option<&BStr>) -> bool {
         if self.allow.is_empty() && self.deny.is_empty() {
             return true;
         }
@@ -49,7 +49,7 @@ impl FilterList {
         }
     }
 
-    pub fn allow(
+    pub(crate) fn allow(
         mut self,
         filenames: Vec<PathBuf>,
     ) -> Result<Self, FilterListError> {
@@ -68,7 +68,7 @@ impl FilterList {
         Ok(self)
     }
 
-    pub fn deny(
+    pub(crate) fn deny(
         mut self,
         filenames: Vec<PathBuf>,
     ) -> Result<Self, FilterListError> {

--- a/crates/pica-toolkit/src/main.rs
+++ b/crates/pica-toolkit/src/main.rs
@@ -7,6 +7,7 @@ extern crate termcolor;
 mod commands;
 mod config;
 mod error;
+mod filter_list;
 mod macros;
 mod progress;
 

--- a/crates/pica-utils/Cargo.toml
+++ b/crates/pica-utils/Cargo.toml
@@ -10,7 +10,5 @@ rust-version.workspace = true
 
 [dependencies]
 bstr = { workspace = true }
-polars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 unicode-normalization = { version =  "0.1.22" }
-thiserror = { workspace = true }

--- a/crates/pica-utils/src/lib.rs
+++ b/crates/pica-utils/src/lib.rs
@@ -1,5 +1,3 @@
-mod filter_list;
 mod translit;
 
-pub use filter_list::{FilterList, FilterListError};
 pub use translit::NormalizationForm;


### PR DESCRIPTION
This PR is necessarry in order to use fuzz tests. Compiling `polars-core` with the compiler flags of `cargo-fuzz` causes `rustc` to stops, because of an oom (out-of-memory) event.