### PR TITLE
Add XOR operator

### DIFF
--- a/crates/pica-matcher/src/common.rs
+++ b/crates/pica-matcher/src/common.rs
@@ -14,6 +14,7 @@ use winnow::{PResult, Parser};
 pub enum BooleanOp {
     And, // and, "&&"
     Or,  // or, "||"
+    Xor, // xor, "^"
 }
 
 /// Strip whitespaces from the beginning and end.

--- a/crates/pica-matcher/src/field_matcher.rs
+++ b/crates/pica-matcher/src/field_matcher.rs
@@ -634,6 +634,7 @@ fn parse_field_matcher_xor(i: &mut &[u8]) -> PResult<FieldMatcher> {
     (
         ws(alt((
             parse_field_matcher_group,
+            parse_field_matcher_and,
             parse_field_matcher_cardinality,
             parse_field_matcher_singleton,
             parse_field_matcher_not,
@@ -645,6 +646,7 @@ fn parse_field_matcher_xor(i: &mut &[u8]) -> PResult<FieldMatcher> {
                 ws(alt(("^", "XOR"))),
                 ws(alt((
                     parse_field_matcher_group,
+                    parse_field_matcher_and,
                     parse_field_matcher_cardinality,
                     parse_field_matcher_singleton,
                     parse_field_matcher_not,
@@ -664,7 +666,6 @@ fn parse_field_matcher_and(i: &mut &[u8]) -> PResult<FieldMatcher> {
     (
         ws(alt((
             parse_field_matcher_group,
-            parse_field_matcher_xor,
             parse_field_matcher_cardinality,
             parse_field_matcher_singleton,
             parse_field_matcher_not,
@@ -676,7 +677,6 @@ fn parse_field_matcher_and(i: &mut &[u8]) -> PResult<FieldMatcher> {
                 ws("&&"),
                 ws(alt((
                     parse_field_matcher_group,
-                    parse_field_matcher_xor,
                     parse_field_matcher_cardinality,
                     parse_field_matcher_singleton,
                     parse_field_matcher_not,
@@ -730,8 +730,8 @@ fn parse_field_matcher_composite(
 ) -> PResult<FieldMatcher> {
     alt((
         parse_field_matcher_or,
-        parse_field_matcher_and,
         parse_field_matcher_xor,
+        parse_field_matcher_and,
     ))
     .parse_next(i)
 }

--- a/crates/pica-matcher/src/record_matcher.rs
+++ b/crates/pica-matcher/src/record_matcher.rs
@@ -1,4 +1,6 @@
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not};
+use std::ops::{
+    BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not,
+};
 use std::str::FromStr;
 
 use bstr::ByteSlice;
@@ -126,6 +128,30 @@ impl BitOrAssign for RecordMatcher {
         self.field_matcher = FieldMatcher::Composite {
             lhs: Box::new(self.field_matcher.clone()),
             op: BooleanOp::Or,
+            rhs: Box::new(rhs.field_matcher),
+        };
+    }
+}
+
+impl BitXor for RecordMatcher {
+    type Output = Self;
+
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        RecordMatcher {
+            field_matcher: FieldMatcher::Composite {
+                lhs: Box::new(self.field_matcher),
+                op: BooleanOp::Xor,
+                rhs: Box::new(rhs.field_matcher),
+            },
+        }
+    }
+}
+
+impl BitXorAssign for RecordMatcher {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        self.field_matcher = FieldMatcher::Composite {
+            lhs: Box::new(self.field_matcher.clone()),
+            op: BooleanOp::Xor,
             rhs: Box::new(rhs.field_matcher),
         };
     }

--- a/crates/pica-matcher/src/subfield_matcher.rs
+++ b/crates/pica-matcher/src/subfield_matcher.rs
@@ -1014,8 +1014,8 @@ fn parse_or_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
     (
         alt((
             ws(parse_group_matcher),
-            ws(parse_and_matcher),
             ws(parse_xor_matcher),
+            ws(parse_and_matcher),
             ws(parse_subfield_singleton_matcher),
             ws(parse_not_matcher),
         )),
@@ -1025,8 +1025,8 @@ fn parse_or_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
                 ws("||"),
                 alt((
                     ws(parse_group_matcher),
-                    ws(parse_and_matcher),
                     ws(parse_xor_matcher),
+                    ws(parse_and_matcher),
                     ws(parse_subfield_singleton_matcher),
                     ws(parse_not_matcher),
                 )),
@@ -1044,7 +1044,6 @@ fn parse_and_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
     (
         ws(alt((
             parse_group_matcher,
-            parse_xor_matcher,
             parse_singleton_matcher.map(SubfieldMatcher::Singleton),
             parse_not_matcher,
         ))),
@@ -1054,7 +1053,6 @@ fn parse_and_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
                 ws("&&"),
                 ws(alt((
                     parse_group_matcher,
-                    parse_xor_matcher,
                     parse_singleton_matcher
                         .map(SubfieldMatcher::Singleton),
                     parse_not_matcher,
@@ -1073,6 +1071,7 @@ fn parse_xor_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
     (
         ws(alt((
             parse_group_matcher,
+            parse_and_matcher,
             parse_singleton_matcher.map(SubfieldMatcher::Singleton),
             parse_not_matcher,
         ))),
@@ -1082,6 +1081,7 @@ fn parse_xor_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
                 ws(alt(("^", "XOR"))),
                 ws(alt((
                     parse_group_matcher,
+                    parse_and_matcher,
                     parse_singleton_matcher
                         .map(SubfieldMatcher::Singleton),
                     parse_not_matcher,
@@ -1097,7 +1097,7 @@ fn parse_xor_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
 
 #[inline]
 fn parse_composite_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
-    alt((parse_or_matcher, parse_and_matcher, parse_xor_matcher))
+    alt((parse_or_matcher, parse_xor_matcher, parse_and_matcher))
         .parse_next(i)
 }
 

--- a/crates/pica-matcher/src/subfield_matcher.rs
+++ b/crates/pica-matcher/src/subfield_matcher.rs
@@ -1,7 +1,7 @@
 //! Matcher that works on PICA+ [Subfields](pica_record::Subfield).
 
 use std::cell::RefCell;
-use std::ops::{BitAnd, BitOr};
+use std::ops::{BitAnd, BitOr, BitXor};
 use std::str::FromStr;
 
 use bstr::ByteSlice;
@@ -918,15 +918,20 @@ impl SubfieldMatcher {
             Self::Singleton(m) => m.is_match(subfields, options),
             Self::Group(m) => m.is_match(subfields, options),
             Self::Not(m) => !m.is_match(subfields, options),
-            Self::Composite { lhs, op, rhs } => {
-                if *op == BooleanOp::And {
+            Self::Composite { lhs, op, rhs } => match op {
+                BooleanOp::And => {
                     lhs.is_match(subfields.clone(), options)
                         && rhs.is_match(subfields, options)
-                } else {
+                }
+                BooleanOp::Or => {
                     lhs.is_match(subfields.clone(), options)
                         || rhs.is_match(subfields, options)
                 }
-            }
+                BooleanOp::Xor => {
+                    lhs.is_match(subfields.clone(), options)
+                        != rhs.is_match(subfields, options)
+                }
+            },
         }
     }
 }
@@ -1010,6 +1015,7 @@ fn parse_or_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
         alt((
             ws(parse_group_matcher),
             ws(parse_and_matcher),
+            ws(parse_xor_matcher),
             ws(parse_subfield_singleton_matcher),
             ws(parse_not_matcher),
         )),
@@ -1020,6 +1026,7 @@ fn parse_or_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
                 alt((
                     ws(parse_group_matcher),
                     ws(parse_and_matcher),
+                    ws(parse_xor_matcher),
                     ws(parse_subfield_singleton_matcher),
                     ws(parse_not_matcher),
                 )),
@@ -1037,6 +1044,7 @@ fn parse_and_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
     (
         ws(alt((
             parse_group_matcher,
+            parse_xor_matcher,
             parse_singleton_matcher.map(SubfieldMatcher::Singleton),
             parse_not_matcher,
         ))),
@@ -1046,6 +1054,7 @@ fn parse_and_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
                 ws("&&"),
                 ws(alt((
                     parse_group_matcher,
+                    parse_xor_matcher,
                     parse_singleton_matcher
                         .map(SubfieldMatcher::Singleton),
                     parse_not_matcher,
@@ -1060,8 +1069,36 @@ fn parse_and_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
 }
 
 #[inline]
+fn parse_xor_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
+    (
+        ws(alt((
+            parse_group_matcher,
+            parse_singleton_matcher.map(SubfieldMatcher::Singleton),
+            parse_not_matcher,
+        ))),
+        repeat(
+            1..,
+            preceded(
+                ws(alt(("^", "XOR"))),
+                ws(alt((
+                    parse_group_matcher,
+                    parse_singleton_matcher
+                        .map(SubfieldMatcher::Singleton),
+                    parse_not_matcher,
+                ))),
+            ),
+        ),
+    )
+        .map(|(head, remainder): (_, Vec<_>)| {
+            remainder.into_iter().fold(head, |prev, next| prev ^ next)
+        })
+        .parse_next(i)
+}
+
+#[inline]
 fn parse_composite_matcher(i: &mut &[u8]) -> PResult<SubfieldMatcher> {
-    alt((parse_or_matcher, parse_and_matcher)).parse_next(i)
+    alt((parse_or_matcher, parse_and_matcher, parse_xor_matcher))
+        .parse_next(i)
 }
 
 pub fn parse_subfield_matcher(
@@ -1116,6 +1153,18 @@ impl BitOr for SubfieldMatcher {
         Self::Composite {
             lhs: Box::new(self),
             op: BooleanOp::Or,
+            rhs: Box::new(rhs),
+        }
+    }
+}
+
+impl BitXor for SubfieldMatcher {
+    type Output = Self;
+
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        Self::Composite {
+            lhs: Box::new(self),
+            op: BooleanOp::Xor,
             rhs: Box::new(rhs),
         }
     }

--- a/crates/pica-matcher/tests/field_matcher/mod.rs
+++ b/crates/pica-matcher/tests/field_matcher/mod.rs
@@ -764,8 +764,144 @@ fn field_matcher_composite_xor() {
         &options
     ));
 
+    let matcher = FieldMatcher::new("012A? ^ (012B? || 012C?)");
+    let options = MatcherOptions::default();
+
+    assert!(!matcher.is_match(
+        vec![
+            &field!("013A", '0', ""),
+            &field!("013B", '0', ""),
+            &field!("013C", '0', "")
+        ],
+        &options
+    ));
+    assert!(matcher.is_match(
+        vec![
+            &field!("013A", '0', ""),
+            &field!("013B", '0', ""),
+            &field!("012C", '0', "")
+        ],
+        &options
+    ));
+    assert!(matcher.is_match(
+        vec![
+            &field!("013A", '0', ""),
+            &field!("012B", '0', ""),
+            &field!("013C", '0', "")
+        ],
+        &options
+    ));
+    assert!(matcher.is_match(
+        vec![
+            &field!("013A", '0', ""),
+            &field!("012B", '0', ""),
+            &field!("012C", '0', "")
+        ],
+        &options
+    ));
+    assert!(matcher.is_match(
+        vec![
+            &field!("012A", '0', ""),
+            &field!("013B", '0', ""),
+            &field!("013C", '0', "")
+        ],
+        &options
+    ));
+    assert!(!matcher.is_match(
+        vec![
+            &field!("012A", '0', ""),
+            &field!("013B", '0', ""),
+            &field!("012C", '0', "")
+        ],
+        &options
+    ));
+    assert!(!matcher.is_match(
+        vec![
+            &field!("012A", '0', ""),
+            &field!("012B", '0', ""),
+            &field!("013C", '0', "")
+        ],
+        &options
+    ));
+    assert!(!matcher.is_match(
+        vec![
+            &field!("012A", '0', ""),
+            &field!("012B", '0', ""),
+            &field!("012C", '0', "")
+        ],
+        &options
+    ));
+
     // precedence AND
     let matcher = FieldMatcher::new("012A? ^ 012B? && 012C?");
+    let options = MatcherOptions::default();
+
+    assert!(!matcher.is_match(
+        vec![
+            &field!("013A", '0', ""),
+            &field!("013B", '0', ""),
+            &field!("013C", '0', "")
+        ],
+        &options
+    ));
+    assert!(!matcher.is_match(
+        vec![
+            &field!("013A", '0', ""),
+            &field!("013B", '0', ""),
+            &field!("012C", '0', "")
+        ],
+        &options
+    ));
+    assert!(!matcher.is_match(
+        vec![
+            &field!("013A", '0', ""),
+            &field!("012B", '0', ""),
+            &field!("013C", '0', "")
+        ],
+        &options
+    ));
+    assert!(matcher.is_match(
+        vec![
+            &field!("013A", '0', ""),
+            &field!("012B", '0', ""),
+            &field!("012C", '0', "")
+        ],
+        &options
+    ));
+    assert!(matcher.is_match(
+        vec![
+            &field!("012A", '0', ""),
+            &field!("013B", '0', ""),
+            &field!("013C", '0', "")
+        ],
+        &options
+    ));
+    assert!(matcher.is_match(
+        vec![
+            &field!("012A", '0', ""),
+            &field!("013B", '0', ""),
+            &field!("012C", '0', "")
+        ],
+        &options
+    ));
+    assert!(matcher.is_match(
+        vec![
+            &field!("012A", '0', ""),
+            &field!("012B", '0', ""),
+            &field!("013C", '0', "")
+        ],
+        &options
+    ));
+    assert!(!matcher.is_match(
+        vec![
+            &field!("012A", '0', ""),
+            &field!("012B", '0', ""),
+            &field!("012C", '0', "")
+        ],
+        &options
+    ));
+
+    let matcher = FieldMatcher::new("(012A? ^ 012B?) && 012C?");
     let options = MatcherOptions::default();
 
     assert!(!matcher.is_match(

--- a/crates/pica-matcher/tests/subfield_matcher/mod.rs
+++ b/crates/pica-matcher/tests/subfield_matcher/mod.rs
@@ -1041,13 +1041,26 @@ fn subfield_matcher_xor() -> anyhow::Result<()> {
     assert!(!matcher.is_match(&subfield!('a', "dcd"), &options));
     assert!(!matcher.is_match(&subfield!('a', "ddb"), &options));
     assert!(matcher.is_match(&subfield!('a', "dcb"), &options));
-    assert!(!matcher.is_match(&subfield!('a', "add"), &options));
+    assert!(matcher.is_match(&subfield!('a', "add"), &options));
     assert!(matcher.is_match(&subfield!('a', "acd"), &options));
-    assert!(!matcher.is_match(&subfield!('a', "adb"), &options));
+    assert!(matcher.is_match(&subfield!('a', "adb"), &options));
     assert!(!matcher.is_match(&subfield!('a', "acb"), &options));
 
     let matcher =
         SubfieldMatcher::new("a =? 'c' && a =^ 'a' ^ a =$ 'b'");
+    let options = MatcherOptions::default();
+
+    assert!(!matcher.is_match(&subfield!('a', "ddd"), &options));
+    assert!(matcher.is_match(&subfield!('a', "ddb"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "add"), &options));
+    assert!(matcher.is_match(&subfield!('a', "adb"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "dcd"), &options));
+    assert!(matcher.is_match(&subfield!('a', "dcb"), &options));
+    assert!(matcher.is_match(&subfield!('a', "acd"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "acb"), &options));
+
+    let matcher =
+        SubfieldMatcher::new("a =? 'c' && (a =^ 'a' ^ a =$ 'b')");
     let options = MatcherOptions::default();
 
     assert!(!matcher.is_match(&subfield!('a', "ddd"), &options));

--- a/crates/pica-matcher/tests/subfield_matcher/mod.rs
+++ b/crates/pica-matcher/tests/subfield_matcher/mod.rs
@@ -764,6 +764,24 @@ fn subfield_matcher_bit_or() -> TestResult {
 }
 
 #[test]
+fn subfield_matcher_bit_xor() -> TestResult {
+    let lhs = SubfieldMatcher::from_str("a =^ 'a'")?;
+    let rhs = SubfieldMatcher::from_str("a =$ 'b'")?;
+    let matcher = lhs ^ rhs;
+
+    assert!(!matcher
+        .is_match(&subfield!('a', "cc"), &MatcherOptions::default()));
+    assert!(matcher
+        .is_match(&subfield!('a', "ac"), &MatcherOptions::default()));
+    assert!(matcher
+        .is_match(&subfield!('a', "bb"), &MatcherOptions::default()));
+    assert!(!matcher
+        .is_match(&subfield!('a', "ab"), &MatcherOptions::default()));
+
+    Ok(())
+}
+
+#[test]
 fn subfield_matcher_not() -> TestResult {
     // group
     let matcher = SubfieldMatcher::from_str("!(a == 'bcd')")?;
@@ -932,6 +950,114 @@ fn subfield_matcher_and() -> anyhow::Result<()> {
     assert!(!matcher.is_match(&subfield!('a', "abba"), &options));
     assert!(!matcher.is_match(&subfield!('a', "baba"), &options));
     assert!(matcher.is_match(&subfield!('a', "cbcb"), &options));
+
+    Ok(())
+}
+
+#[test]
+fn subfield_matcher_xor() -> anyhow::Result<()> {
+    // singleton
+    let matcher = SubfieldMatcher::new("a =^ 'a' ^ a =$ 'b'");
+    let options = MatcherOptions::default();
+
+    assert!(!matcher.is_match(&subfield!('a', "cc"), &options));
+    assert!(matcher.is_match(&subfield!('a', "ac"), &options));
+    assert!(matcher.is_match(&subfield!('a', "cb"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "ab"), &options));
+
+    let subfields = [&subfield!('a', "dd"), &subfield!('a', "cb")];
+    assert!(matcher.is_match(subfields, &options));
+
+    let matcher = SubfieldMatcher::new("a =^ 'a' XOR a =$ 'b'");
+    let options = MatcherOptions::default();
+
+    assert!(!matcher.is_match(&subfield!('a', "cc"), &options));
+    assert!(matcher.is_match(&subfield!('a', "ac"), &options));
+    assert!(matcher.is_match(&subfield!('a', "cb"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "ab"), &options));
+
+    // group
+    let matcher =
+        SubfieldMatcher::new("a =^ 'a' ^ (a =$ 'b' || a =$ 'c')");
+    let options = MatcherOptions::default();
+
+    assert!(!matcher.is_match(&subfield!('a', "dd"), &options));
+    assert!(matcher.is_match(&subfield!('a', "ad"), &options));
+    assert!(matcher.is_match(&subfield!('a', "cb"), &options));
+    assert!(matcher.is_match(&subfield!('a', "cc"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "ab"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "ac"), &options));
+
+    let subfields = [&subfield!('a', "ab"), &subfield!('a', "ac")];
+    assert!(!matcher.is_match(subfields, &options));
+
+    let subfields = [&subfield!('a', "dd"), &subfield!('a', "db")];
+    assert!(matcher.is_match(subfields, &options));
+
+    // not
+    let matcher =
+        SubfieldMatcher::new("a =^ 'a' ^ !(a =$ 'b' || a =$ 'c')");
+    let options = MatcherOptions::default();
+
+    assert!(matcher.is_match(&subfield!('a', "dd"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "ad"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "cb"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "cc"), &options));
+    assert!(matcher.is_match(&subfield!('a', "ab"), &options));
+    assert!(matcher.is_match(&subfield!('a', "ac"), &options));
+
+    // precedence
+    let matcher =
+        SubfieldMatcher::new("a =^ 'a' ^ a =$ 'b' || a =? 'c'");
+    let options = MatcherOptions::default();
+
+    assert!(!matcher.is_match(&subfield!('a', "ddd"), &options));
+    assert!(matcher.is_match(&subfield!('a', "dcd"), &options));
+    assert!(matcher.is_match(&subfield!('a', "ddb"), &options));
+    assert!(matcher.is_match(&subfield!('a', "dcb"), &options));
+    assert!(matcher.is_match(&subfield!('a', "add"), &options));
+    assert!(matcher.is_match(&subfield!('a', "acd"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "adb"), &options));
+    assert!(matcher.is_match(&subfield!('a', "acb"), &options));
+
+    let matcher =
+        SubfieldMatcher::new("a =? 'c' || a =^ 'a' ^ a =$ 'b'");
+    let options = MatcherOptions::default();
+
+    assert!(!matcher.is_match(&subfield!('a', "ddd"), &options));
+    assert!(matcher.is_match(&subfield!('a', "dcd"), &options));
+    assert!(matcher.is_match(&subfield!('a', "ddb"), &options));
+    assert!(matcher.is_match(&subfield!('a', "dcb"), &options));
+    assert!(matcher.is_match(&subfield!('a', "add"), &options));
+    assert!(matcher.is_match(&subfield!('a', "acd"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "adb"), &options));
+    assert!(matcher.is_match(&subfield!('a', "acb"), &options));
+
+    let matcher =
+        SubfieldMatcher::new("a =^ 'a' ^ a =$ 'b' && a =? 'c'");
+    let options = MatcherOptions::default();
+
+    assert!(!matcher.is_match(&subfield!('a', "ddd"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "dcd"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "ddb"), &options));
+    assert!(matcher.is_match(&subfield!('a', "dcb"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "add"), &options));
+    assert!(matcher.is_match(&subfield!('a', "acd"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "adb"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "acb"), &options));
+
+    let matcher =
+        SubfieldMatcher::new("a =? 'c' && a =^ 'a' ^ a =$ 'b'");
+    let options = MatcherOptions::default();
+
+    assert!(!matcher.is_match(&subfield!('a', "ddd"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "dcd"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "ddb"), &options));
+    assert!(matcher.is_match(&subfield!('a', "dcb"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "add"), &options));
+    assert!(matcher.is_match(&subfield!('a', "acd"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "adb"), &options));
+    assert!(!matcher.is_match(&subfield!('a', "acb"), &options));
 
     Ok(())
 }

--- a/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-field-f.stdin
+++ b/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-field-f.stdin
@@ -1,0 +1,1 @@
+../data/ffm.dat

--- a/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-field-f.toml
+++ b/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-field-f.toml
@@ -1,0 +1,5 @@
+bin.name = "pica"
+args = "filter '008A.a == \"s\" ^ 008A.a == \"f\"'"
+status = "success"
+stdout = ""
+stderr = ""

--- a/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-field-t.stdin
+++ b/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-field-t.stdin
@@ -1,0 +1,1 @@
+../data/ffm.dat

--- a/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-field-t.stdout
+++ b/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-field-t.stdout
@@ -1,0 +1,1 @@
+../data/ffm.dat

--- a/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-field-t.toml
+++ b/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-field-t.toml
@@ -1,0 +1,4 @@
+bin.name = "pica"
+args = "filter '008A.a == \"s\" ^ 008A.a == \"x\"'"
+status = "success"
+stderr = ""

--- a/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-subfield-f.stdin
+++ b/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-subfield-f.stdin
@@ -1,0 +1,1 @@
+../data/ffm.dat

--- a/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-subfield-f.toml
+++ b/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-subfield-f.toml
@@ -1,0 +1,5 @@
+bin.name = "pica"
+args = "filter '008A{a == \"s\" ^ a == \"f\"}'"
+status = "success"
+stdout = ""
+stderr = ""

--- a/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-subfield-t.stdin
+++ b/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-subfield-t.stdin
@@ -1,0 +1,1 @@
+../data/ffm.dat

--- a/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-subfield-t.stdout
+++ b/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-subfield-t.stdout
@@ -1,0 +1,1 @@
+../data/ffm.dat

--- a/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-subfield-t.toml
+++ b/crates/pica-toolkit/tests/snapshot/filter/0790-filter-xor-subfield-t.toml
@@ -1,0 +1,4 @@
+bin.name = "pica"
+args = "filter '008A{a == \"s\" ^ a == \"x\"}'"
+status = "success"
+stderr = ""


### PR DESCRIPTION
This PR adds the `XOR` (`^`) boolean connective to field- and subfield-matcher expressions. An exclusive or evaluates to `true` if both expressions differ (one is true, one is false). For more than two inputs the `XOR`-operator evaluates to `true` if the number of true inputs is odd.

## Operator Precedence

The precedence of the `XOR` expression is lower than `AND` (`&&`) and higher than `OR` (`||`), that is `A ^ B && C` is equivalent to `A ^ (B && C)` and `A ^ B || C` is equivalent to `(A ^ B) || C`.

## Examples

```console
$ pica filter "008A.a == 's' ^ 008A.a == 'f'" DUMP.dat -o out.dat
$ pica filter "008A.a == 's' XOR 008A.a == 'f'" DUMP.dat -o out.dat
$ pica filter "008A{a == 's' ^ a == 'f'} DUMP.dat -o out.dat
$ pica filter "008A{a == 's' XOR a == 'f'} DUMP.dat -o out.dat
```

## Notes

Because it is very rare to use more than two input variables in an `XOR`-expression, it is not planned to add an `--xor` option to the command-line interface.