### PR TITLE
Add group modifiers (format)

### DIFF
--- a/crates/pica-format/src/lib.rs
+++ b/crates/pica-format/src/lib.rs
@@ -194,6 +194,7 @@ struct Group {
 struct Modifier {
     lowercase: bool,
     uppercase: bool,
+    remove_ws: bool,
     trim: bool,
 }
 
@@ -208,6 +209,10 @@ impl Modifier {
         self
     }
 
+    pub(crate) fn remove_ws(&mut self, yes: bool) -> &mut Self {
+        self.remove_ws = yes;
+        self
+    }
     pub(crate) fn trim(&mut self, yes: bool) -> &mut Self {
         self.trim = yes;
         self
@@ -245,6 +250,10 @@ impl Formatter for Group {
 
         if self.modifier.trim {
             acc = acc.trim().to_string();
+        }
+
+        if self.modifier.remove_ws {
+            acc = acc.replace(' ', "").to_string();
         }
 
         if self.modifier.lowercase {

--- a/crates/pica-format/src/lib.rs
+++ b/crates/pica-format/src/lib.rs
@@ -187,6 +187,31 @@ impl Formatter for Value {
 struct Group {
     fragments: Box<Fragments>,
     bounds: RangeTo<usize>,
+    modifier: Modifier,
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+struct Modifier {
+    lowercase: bool,
+    uppercase: bool,
+    trim: bool,
+}
+
+impl Modifier {
+    pub(crate) fn lowercase(&mut self, yes: bool) -> &mut Self {
+        self.lowercase = yes;
+        self
+    }
+
+    pub(crate) fn uppercase(&mut self, yes: bool) -> &mut Self {
+        self.uppercase = yes;
+        self
+    }
+
+    pub(crate) fn trim(&mut self, yes: bool) -> &mut Self {
+        self.trim = yes;
+        self
+    }
 }
 
 impl Formatter for Group {
@@ -216,6 +241,18 @@ impl Formatter for Group {
                 acc.push_str(&value);
                 count += 1;
             }
+        }
+
+        if self.modifier.trim {
+            acc = acc.trim().to_string();
+        }
+
+        if self.modifier.lowercase {
+            acc = acc.to_lowercase();
+        }
+
+        if self.modifier.uppercase {
+            acc = acc.to_uppercase();
         }
 
         acc

--- a/crates/pica-format/src/parse.rs
+++ b/crates/pica-format/src/parse.rs
@@ -99,7 +99,7 @@ fn decrement_group_level() {
 fn parse_modifier(i: &mut &[u8]) -> PResult<Option<Modifier>> {
     opt(preceded(
         '?',
-        repeat(1.., alt(('L', 'U', 'T'))).map(|codes: Vec<_>| {
+        repeat(1.., alt(('L', 'U', 'T', 'W'))).map(|codes: Vec<_>| {
             let mut modifier = Modifier::default();
             if codes.contains(&'L') {
                 modifier.lowercase(true);
@@ -107,6 +107,10 @@ fn parse_modifier(i: &mut &[u8]) -> PResult<Option<Modifier>> {
 
             if codes.contains(&'U') {
                 modifier.uppercase(true);
+            }
+
+            if codes.contains(&'W') {
+                modifier.remove_ws(true);
             }
 
             if codes.contains(&'T') {

--- a/crates/pica-format/tests/integration.rs
+++ b/crates/pica-format/tests/integration.rs
@@ -90,9 +90,10 @@ fn test_format_modifier_trim() -> TestResult {
 #[test]
 fn test_format_modifier_uppercase() -> TestResult {
     let ada = ByteRecord::from_bytes(ada_lovelace()).expect("record");
-    let fmt = Format::from_str("028A{ a <$> (?U ', ' d <*> ' ' c) }")?;
+    let fmt =
+        Format::from_str("028A{ (?U a) <$> (?U ', ' d <*> ' ' c) }")?;
     let result = ada.format(&fmt, &Default::default());
-    assert_eq!(result, vec!["Lovelace, ADA KING OF".to_string()]);
+    assert_eq!(result, vec!["LOVELACE, ADA KING OF".to_string()]);
 
     Ok(())
 }

--- a/crates/pica-format/tests/integration.rs
+++ b/crates/pica-format/tests/integration.rs
@@ -88,6 +88,16 @@ fn test_format_modifier_trim() -> TestResult {
 }
 
 #[test]
+fn test_format_modifier_remove_ws() -> TestResult {
+    let ada = ByteRecord::from_bytes(ada_lovelace()).expect("record");
+    let fmt = Format::from_str("028A{ (?W d) }")?;
+    let result = ada.format(&fmt, &Default::default());
+    assert_eq!(result, vec!["AdaKing"]);
+
+    Ok(())
+}
+
+#[test]
 fn test_format_modifier_uppercase() -> TestResult {
     let ada = ByteRecord::from_bytes(ada_lovelace()).expect("record");
     let fmt =

--- a/crates/pica-format/tests/integration.rs
+++ b/crates/pica-format/tests/integration.rs
@@ -78,6 +78,36 @@ fn test_format_quantifier() -> TestResult {
 }
 
 #[test]
+fn test_format_modifier_trim() -> TestResult {
+    let ada = ByteRecord::from_bytes(ada_lovelace()).expect("record");
+    let fmt = Format::from_str("042A{ (?T 'GND-SC: ' a.. ' ') }")?;
+    let result = ada.format(&fmt, &Default::default());
+    assert_eq!(result, vec!["GND-SC: 28p GND-SC: 9.5p"]);
+
+    Ok(())
+}
+
+#[test]
+fn test_format_modifier_uppercase() -> TestResult {
+    let ada = ByteRecord::from_bytes(ada_lovelace()).expect("record");
+    let fmt = Format::from_str("028A{ a <$> (?U ', ' d <*> ' ' c) }")?;
+    let result = ada.format(&fmt, &Default::default());
+    assert_eq!(result, vec!["Lovelace, ADA KING OF".to_string()]);
+
+    Ok(())
+}
+
+#[test]
+fn test_format_modifier_lowercase() -> TestResult {
+    let ada = ByteRecord::from_bytes(ada_lovelace()).expect("record");
+    let fmt = Format::from_str("028A{ a <$> (?L ', ' d <*> ' ' c) }")?;
+    let result = ada.format(&fmt, &Default::default());
+    assert_eq!(result, vec!["Lovelace, ada king of".to_string()]);
+
+    Ok(())
+}
+
+#[test]
 fn test_format_conference() -> TestResult {
     let fmt = Format::new(
         "030[A@]{(n ' ') <*> a <$> (', ' d <*> ' (' [cg] ')')}",


### PR DESCRIPTION
This PR adds the group modifiers `U` (uppercase), `L` (lowercase), `W` (remove white-spaces) and `T` (remove leading and trailing white-spaces). Modifiers must follow a single `?` after the opening parenthesis. It's possible to combine multiple modifiers like `(?WU ...)` which transforms the result to uppercase and remove all white-space characters.

### Example

```sh
$ pica select '003@.0, 006Y{ (?W "https://isni.org/isni/" 0) | S == "isni" }' goethe.dat
118540238,https://isni.org/isni/0000000120999104
```