### PR TITLE
Disable `docs` jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,10 +209,43 @@ jobs:
       - run: |
           cargo miri test -p ${{ matrix.item.package }} ${{ matrix.item.flags }}
 
-  docs:
+  # docs:
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: write
+  #   needs:
+  #     - audit
+  #     - careful
+  #     - check
+  #     - clippy
+  #     - cross
+  #     - deny
+  #     - fmt
+  #     - fuzz
+  #     - miri
+  #     - outdated
+  #     - test
+  #     - udeps
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@nightly
+  #     - uses: Swatinem/rust-cache@v2
+  #     - uses: peaceiris/actions-hugo@v2
+  #       with:
+  #         hugo-version: 'latest'
+  #         extended: true
+  #     - run: make docs
+  #     - name: deploy
+  #       uses: peaceiris/actions-gh-pages@v3
+  #       if: ${{ github.ref == 'refs/heads/main' }}
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         publish_dir: target/docs
+  #         keep_files: false
+  #         force_orphan: true
+
+  ci:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     needs:
       - audit
       - careful
@@ -227,19 +260,4 @@ jobs:
       - test
       - udeps
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
-      - uses: peaceiris/actions-hugo@v2
-        with:
-          hugo-version: 'latest'
-          extended: true
-      - run: make docs
-      - name: deploy
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: target/docs
-          keep_files: false
-          force_orphan: true
+      - run: exit 0


### PR DESCRIPTION
The project documentation will be replaced by an PDF manual. It is no longer necessary to update the website.