### PR TITLE
Add minimum support of subfields (PICA Path)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ winnow = { version = "0.6.18" }
 [features]
 serde = ["dep:serde", "bstr/serde"]
 unstable = []
+compat = []
 
 [dev-dependencies]
 anyhow = { version = "1.0" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-pica-record = { path = "..", features = ["unstable"] }
+pica-record = { path = "..", features = ["unstable", "compat"] }
 libfuzzer-sys = "0.4"
 
 [[bin]]

--- a/src/matcher/subfield/parser.rs
+++ b/src/matcher/subfield/parser.rs
@@ -18,7 +18,9 @@ use crate::matcher::operator::{
     parse_relational_operator, RelationalOp,
 };
 use crate::matcher::quantifier::parse_quantifier;
-use crate::parser::{parse_string, parse_subfield_codes, ws};
+use crate::parser::{
+    parse_string, parse_subfield_codes, parse_subfield_codes_compat, ws,
+};
 use crate::primitives::parse::parse_subfield_code;
 
 /// Parses a [ExistsMatcher] expression.
@@ -42,7 +44,11 @@ pub(crate) fn parse_relation_matcher(
     (
         opt(ws(terminated(parse_quantifier, multispace1)))
             .map(Option::unwrap_or_default),
-        ws(parse_subfield_codes),
+        alt((
+            ws(parse_subfield_codes),
+            #[cfg(feature = "compat")]
+            ws(parse_subfield_codes_compat),
+        )),
         ws(parse_relational_operator)
             .verify(RelationalOp::is_str_applicable),
         ws(parse_string),

--- a/src/matcher/subfield/parser.rs
+++ b/src/matcher/subfield/parser.rs
@@ -18,9 +18,7 @@ use crate::matcher::operator::{
     parse_relational_operator, RelationalOp,
 };
 use crate::matcher::quantifier::parse_quantifier;
-use crate::parser::{
-    parse_string, parse_subfield_codes, parse_subfield_codes_compat, ws,
-};
+use crate::parser::{parse_string, parse_subfield_codes, ws};
 use crate::primitives::parse::parse_subfield_code;
 
 /// Parses a [ExistsMatcher] expression.
@@ -47,7 +45,7 @@ pub(crate) fn parse_relation_matcher(
         alt((
             ws(parse_subfield_codes),
             #[cfg(feature = "compat")]
-            ws(parse_subfield_codes_compat),
+            ws(crate::parser::parse_subfield_codes_compat),
         )),
         ws(parse_relational_operator)
             .verify(RelationalOp::is_str_applicable),


### PR DESCRIPTION
This change reintroduces the minimum support of subfields according to the PICA Path specification. This feature must be activated explicitly with `--feature compat`.