### PR TITLE
perf(select): Use byte records instead of string records

### DIFF
--- a/crates/pica-cli/src/commands/select.rs
+++ b/crates/pica-cli/src/commands/select.rs
@@ -211,7 +211,7 @@ impl Select {
             let mut reader =
                 ReaderBuilder::new().from_path(filename)?;
 
-            while let Some(result) = reader.next_string_record() {
+            while let Some(result) = reader.next_byte_record() {
                 match result {
                     Err(e) if e.skip_parse_err(skip_invalid) => {
                         progress.update(true);
@@ -221,7 +221,7 @@ impl Select {
                     Ok(ref record) => {
                         progress.update(false);
 
-                        if !filter_set.check(record.ppn().into()) {
+                        if !filter_set.check(record.ppn()) {
                             continue;
                         }
 
@@ -236,7 +236,7 @@ impl Select {
                         let outcome = record.query(&query, &options);
                         for row in outcome.iter() {
                             if self.no_empty_columns
-                                && row.iter().any(String::is_empty)
+                                && row.iter().any(|e| e.is_empty())
                             {
                                 continue;
                             }
@@ -253,7 +253,7 @@ impl Select {
                                 seen.insert(hash);
                             }
 
-                            if !row.iter().all(String::is_empty) {
+                            if !row.iter().all(|e| e.is_empty()) {
                                 if self.nf.is_none() {
                                     writer.write_record(row)?;
                                 } else {
@@ -262,7 +262,7 @@ impl Select {
                                             (crate::translit::translit(
                                                 self.nf.as_ref(),
                                             ))(
-                                                s
+                                                s.to_string()
                                             )
                                         }),
                                     )?;


### PR DESCRIPTION
```
 Benchmark 1: ./pica-v0.25 select -s -H 'ppn,gnd_id,label' '003@.0,041A/*{ (9, a) | 9? && 7 =~ "^T[bfgpsu][1z]$" }' DUMP.dat --where '002@.0 =^ "O" && 041A/*.9?' -o out.csv
  Time (mean ± σ):     261.160 s ±  2.054 s    [User: 240.933 s, System: 18.878 s]
  Range (min … max):   259.707 s … 262.612 s    2 runs

Benchmark 2: ./pica-main select -s -H 'ppn,gnd_id,label' '003@.0,041A/*{ (9, a) | 9? && 7 =~ "^T[bfgpsu][1z]$" }' DUMP.dat --where '002@.0 =^ "O" && 041A/*.9?' -o out.csv
  Time (mean ± σ):     243.547 s ±  1.746 s    [User: 223.634 s, System: 18.478 s]
  Range (min … max):   242.312 s … 244.782 s    2 runs

Summary
  './pica-main select -s -H 'ppn,gnd_id,label' '003@.0,041A/*{ (9, a) | 9? && 7 =~ "^T[bfgpsu][1z]$" }' DUMP.dat --where '002@.0 =^ "O" && 041A/*.9?' -o out.csv' ran
    1.07 ± 0.01 times faster than './pica-v0.25 select -s -H 'ppn,gnd_id,label' '003@.0,041A/*{ (9, a) | 9? && 7 =~ "^T[bfgpsu][1z]$" }' DUMP.dat --where '002@.0 =^ "O" && 041A/*.9?' -o out.csv'
```