### PR TITLE
feat(sample): provide filter options

### DIFF
--- a/crates/pica-cli/src/commands/sample.rs
+++ b/crates/pica-cli/src/commands/sample.rs
@@ -8,6 +8,7 @@ use rand::{rng, Rng, SeedableRng};
 
 use crate::config::Config;
 use crate::error::CliResult;
+use crate::prelude::translit;
 use crate::progress::Progress;
 
 /// Selects a random permutation of records of the given sample size
@@ -34,6 +35,42 @@ pub(crate) struct Sample {
     /// random records.
     #[arg(long, value_name = "number")]
     seed: Option<u64>,
+
+    /// When this flag is provided, comparison operations will be
+    /// search case insensitive
+    #[arg(long, short)]
+    ignore_case: bool,
+
+    /// The minimum score for string similarity comparisons (0 <= score
+    /// < 100).
+    #[arg(long, value_parser = value_parser!(u8).range(0..100),
+          default_value = "75")]
+    strsim_threshold: u8,
+
+    /// A filter expression used for searching
+    #[arg(long = "where")]
+    filter: Option<String>,
+
+    /// Connects the where clause with additional expressions using the
+    /// logical AND-operator (conjunction)
+    ///
+    /// This option can't be combined with `--or`.
+    #[arg(long, requires = "filter", conflicts_with = "or")]
+    and: Vec<String>,
+
+    /// Connects the where clause with additional expressions using the
+    /// logical OR-operator (disjunction)
+    ///
+    /// This option can't be combined with `--and` or `--not`.
+    #[arg(long, requires = "filter", conflicts_with_all = ["and", "not"])]
+    or: Vec<String>,
+
+    /// Connects the where clause with additional expressions using the
+    /// logical NOT-operator (negation)
+    ///
+    /// This option can't be combined with `--or`.
+    #[arg(long, requires = "filter", conflicts_with = "or")]
+    not: Vec<String>,
 
     /// Number of random records
     #[arg(value_parser = value_parser!(u16).range(1..))]
@@ -62,6 +99,25 @@ impl Sample {
         let mut reservoir: Vec<Vec<u8>> =
             Vec::with_capacity(sample_size);
 
+        let matcher = if let Some(matcher) = self.filter {
+            Some(
+                RecordMatcherBuilder::with_transform(
+                    matcher,
+                    translit(config.normalization.as_ref()),
+                )?
+                .and(self.and)?
+                .or(self.or)?
+                .not(self.not)?
+                .build(),
+            )
+        } else {
+            None
+        };
+
+        let options = MatcherOptions::new()
+            .strsim_threshold(self.strsim_threshold as f64 / 100.0)
+            .case_ignore(self.ignore_case);
+
         let mut progress = Progress::new(self.progress);
         let mut i = 0;
 
@@ -78,6 +134,13 @@ impl Sample {
                     Err(e) => return Err(e.into()),
                     Ok(ref record) => {
                         progress.update(false);
+
+                        if let Some(ref matcher) = matcher {
+                            if !matcher.is_match(record, &options) {
+                                continue;
+                            }
+                        }
+
                         let mut data = Vec::<u8>::new();
                         record.write_to(&mut data)?;
 

--- a/crates/pica-cli/tests/sample/mod.rs
+++ b/crates/pica-cli/tests/sample/mod.rs
@@ -139,3 +139,138 @@ fn sample_seed() -> TestResult {
     temp_dir.close().unwrap();
     Ok(())
 }
+
+#[test]
+fn sample_where() -> TestResult {
+    let temp_dir = TempDir::new().unwrap();
+    let samples = temp_dir.child("samples.dat");
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .args(["sample", "-s", "23"])
+        .args(["--where", "003@.0 == '118540238'"])
+        .arg(data_dir().join("DUMP.dat.gz"))
+        .args(["-o", samples.to_str().unwrap()])
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::str::is_empty())
+        .stderr(predicates::str::is_empty());
+
+    assert!(predicates::path::eq_file(data_dir().join("goethe.dat"))
+        .eval(samples.path()));
+
+    temp_dir.close().unwrap();
+    Ok(())
+}
+
+#[test]
+fn sample_where_and() -> TestResult {
+    let temp_dir = TempDir::new().unwrap();
+    let samples = temp_dir.child("samples.dat");
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .args(["sample", "-s", "23"])
+        .args(["--where", "002@.0 =^ 'Tp'"])
+        .args(["--and", "003@.0 == '118540238'"])
+        .arg(data_dir().join("DUMP.dat.gz"))
+        .args(["-o", samples.to_str().unwrap()])
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::str::is_empty())
+        .stderr(predicates::str::is_empty());
+
+    assert!(predicates::path::eq_file(data_dir().join("goethe.dat"))
+        .eval(samples.path()));
+
+    temp_dir.close().unwrap();
+    Ok(())
+}
+
+#[test]
+fn sample_where_not() -> TestResult {
+    let temp_dir = TempDir::new().unwrap();
+    let samples = temp_dir.child("samples.dat");
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .args(["sample", "-s", "23"])
+        .args(["--where", "002@.0 =^ 'Tp'"])
+        .args(["--not", "003@.0 == '118607626'"])
+        .arg(data_dir().join("DUMP.dat.gz"))
+        .args(["-o", samples.to_str().unwrap()])
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::str::is_empty())
+        .stderr(predicates::str::is_empty());
+
+    assert!(predicates::path::eq_file(data_dir().join("goethe.dat"))
+        .eval(samples.path()));
+
+    temp_dir.close().unwrap();
+    Ok(())
+}
+
+#[test]
+fn sample_where_and_not() -> TestResult {
+    let temp_dir = TempDir::new().unwrap();
+    let samples = temp_dir.child("samples.dat");
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .args(["sample", "-s", "23"])
+        .args(["--where", "002@.0 =^ 'Tp'"])
+        .args(["--and", "003@.0 == '118540238'"])
+        .args(["--not", "002@.0 == 'Tp3'"])
+        .arg(data_dir().join("DUMP.dat.gz"))
+        .args(["-o", samples.to_str().unwrap()])
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::str::is_empty())
+        .stderr(predicates::str::is_empty());
+
+    assert!(predicates::path::eq_file(data_dir().join("goethe.dat"))
+        .eval(samples.path()));
+
+    temp_dir.close().unwrap();
+    Ok(())
+}
+
+#[test]
+fn sample_where_or() -> TestResult {
+    let temp_dir = TempDir::new().unwrap();
+    let samples = temp_dir.child("samples.dat");
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .args(["sample", "-s", "23"])
+        .args(["--where", "003@.0 == '118515551'"])
+        .args(["--or", "003@.0 == '118540238'"])
+        .arg(data_dir().join("DUMP.dat.gz"))
+        .args(["-o", samples.to_str().unwrap()])
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::str::is_empty())
+        .stderr(predicates::str::is_empty());
+
+    assert!(predicates::path::eq_file(data_dir().join("goethe.dat"))
+        .eval(samples.path()));
+
+    temp_dir.close().unwrap();
+    Ok(())
+}

--- a/docs/book/commands/sample.qmd
+++ b/docs/book/commands/sample.qmd
@@ -24,13 +24,6 @@ $ pica sample 200 DUMP.dat.gz -o samples.dat
 `-s`, `--skip-invalid`
 : Überspringt jene Zeilen aus der Eingabe, die nicht dekodiert werden konnten.
 
-`-i`, `--ignore-case`
-: Groß- und Kleinschreibung wird bei Vergleichen ignoriert.
-
-`--strsim-threshold <value>`
-: Festlegen des Schwellenwerts beim Ähnlichkeitsvergleich von Zeichenketten
-mittels `=*`.
-
 `-g`, `--gzip`
 : Komprimieren der Ausgabe im [Gzip]-Format.
 
@@ -41,6 +34,30 @@ deterministische Auswahl zu erhalten.
 `-p`, `--progress`
 : Anzeige des Fortschritts, der die Anzahl der eingelesenen gültigen sowie
 invaliden Datensätze anzeigt.
+
+`-i`, `--ignore-case`
+: Groß- und Kleinschreibung wird bei Vergleichen ignoriert.
+
+`--strsim-threshold <value>`
+: Festlegen des Schwellenwerts beim Ähnlichkeitsvergleich von Zeichenketten
+mittels `=*`.
+
+`--where <filter>`
+: Angabe eines Filters, der auf die eingelesenen Datensätze angewandt wird.
+
+`--and <expr>`
+: Hinzufügen eines zusätzlichen Filters mittels der booleschen
+`&&`-Verknüpfung. Der ursprüngliche Filterausdruck `<filter>` wird zum Ausdruck
+`<filter> && <expr>`.
+
+`--or <expr>`
+: Hinzufügen eines zusätzlichen Filters mittels der booleschen
+`||`-Verknüpfung. Der ursprüngliche Filterausdruck `<filter>` wird zum Ausdruck
+`<filter> || <expr>`.
+
+`--not <expr>`
+: Hinzufügen eines zusätzlichen Filters. Der ursprüngliche Filterausdruck
+`<filter>` wird zum Ausdruck `<filter> && !(<expr>)`.
 
 `-o <path>`, `--outdir <path>`
 : Angabe, in welches Verzeichnis die Partitionen geschrieben werden sollen.
@@ -60,4 +77,5 @@ $ pica sample 3 DUMP.dat.gz | pica select -H 'ppn' '003@.0' -o samples.csv
 
 
 [Reservoir sampling]: https://en.wikipedia.org/wiki/Reservoir_sampling
+[Gzip]: https://de.wikipedia.org/wiki/Gzip
 

--- a/docs/book/commands/sample.qmd
+++ b/docs/book/commands/sample.qmd
@@ -5,10 +5,10 @@ der Eingabe.
 
 ::: {.callout-note}
 Beim Aufruf des Kommandos ist die Anzahl der gültigen Datensätze nicht
-bekannt. Deshalb wird für die Stichprobenziehen das Verfahren [Reservoir
+bekannt. Deshalb wird für die Stichprobenziehung das Verfahren [Reservoir
 sampling] eingesetzt. Hierfür wird während der Laufzeit Arbeitsspeicher
 proportial zum gewünschten Stichprobenumfang $n$ verwendet. Datensätze am
-Anfang der Eingabe haben eine höhere Wahrscheinlichkeit in der Stichproben
+Anfang der Eingabe haben eine höhere Wahrscheinlichkeit, in der Stichprobe
 enthalten zu sein, als Datensätze am Ende.
 :::
 


### PR DESCRIPTION
This PR adds the `--where`, `--or`, and `--not` options to the `sample` command. Now, the following two commands are equivalent:

```
$ pica filter '002@.0 =^ "Tp" && 003@.0 == "118540238"' DUMP.dat.gz | \
      pica sample 23 -o samples.dat

$ pica sample 23 DUMP.dat.gz -o samples.dat \
      --where '002@.0 =^ "Tp"' --and '003@.0 == "118540238"'
```