### PR TITLE
feat: stabilize format strings

### DIFF
--- a/crates/pica-cli/tests/select/format.rs
+++ b/crates/pica-cli/tests/select/format.rs
@@ -1,0 +1,156 @@
+use assert_cmd::Command;
+
+// use assert_fs::TempDir;
+// use assert_fs::prelude::*;
+use crate::prelude::*;
+
+#[test]
+fn format_string_simple() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("select")
+        .arg("003@.0,028A{ a <$> (', ' d <*> ' (' c ')' ) }")
+        .arg(data_dir().join("ada.dat"))
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::ord::eq(
+            "119232022,\"Lovelace, Ada King (of)\"\n",
+        ))
+        .stderr(predicates::str::is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn format_string_with_predicate() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("select")
+        .arg("003@.0,028R{a <$> (', ' d <*> ' (' v ')') | v in ['Vater', 'Mutter']}")
+        .arg(data_dir().join("ada.dat"))
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::ord::eq(
+            "119232022,\"Byron, George Gordon Byron (Vater)\"\n\
+            119232022,\"Byron, Anne Isabella Milbanke Byron (Mutter)\"\n"
+        ))
+        .stderr(predicates::str::is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn format_string_uppercase() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("select")
+        .arg("003@.0,028A{?u a <$> (', ' d <*> ' (' c ')' ) }")
+        .arg(data_dir().join("ada.dat"))
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::ord::eq(
+            "119232022,\"LOVELACE, Ada King (of)\"\n",
+        ))
+        .stderr(predicates::str::is_empty());
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("select")
+        .arg("003@.0,028A{?u a <$> (?u ', ' d <*> ' (' c ')' ) }")
+        .arg(data_dir().join("ada.dat"))
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::ord::eq(
+            "119232022,\"LOVELACE, ADA KING (OF)\"\n",
+        ))
+        .stderr(predicates::str::is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn format_string_lowercase() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("select")
+        .arg("003@.0,028A{?l a <$> (', ' d <*> ' (' c ')' ) }")
+        .arg(data_dir().join("ada.dat"))
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::ord::eq(
+            "119232022,\"lovelace, Ada King (of)\"\n",
+        ))
+        .stderr(predicates::str::is_empty());
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("select")
+        .arg("003@.0,028A{?l a <$> (?l ', ' d <*> ' (' c ')' ) }")
+        .arg(data_dir().join("ada.dat"))
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::ord::eq(
+            "119232022,\"lovelace, ada king (of)\"\n",
+        ))
+        .stderr(predicates::str::is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn format_string_strip_whitespaces() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("select")
+        .arg("003@.0,028A{ a <$> (?w ', ' d <*> ' (' c ')' ) }")
+        .arg(data_dir().join("ada.dat"))
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::ord::eq(
+            "119232022,\"Lovelace,AdaKing(of)\"\n",
+        ))
+        .stderr(predicates::str::is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn format_string_trim() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .arg("select")
+        .arg("003@.0,028A{a <$> (?t ', ' d <*> ' (' c ') ' ) }")
+        .arg(data_dir().join("ada.dat"))
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::ord::eq(
+            "119232022,\"Lovelace, Ada King (of)\"\n",
+        ))
+        .stderr(predicates::str::is_empty());
+
+    Ok(())
+}

--- a/crates/pica-cli/tests/select/mod.rs
+++ b/crates/pica-cli/tests/select/mod.rs
@@ -6,6 +6,8 @@ use assert_fs::prelude::*;
 
 use super::prelude::*;
 
+mod format;
+
 #[test]
 fn select_csv_stdout() -> TestResult {
     let mut cmd = Command::cargo_bin("pica")?;
@@ -769,43 +771,6 @@ fn select_query_path() -> TestResult {
         .code(0)
         .stdout(predicates::ord::eq(
             "119232022,s|z|f\n119232022,w|k|v\n",
-        ))
-        .stderr(predicates::str::is_empty());
-
-    Ok(())
-}
-
-#[test]
-#[cfg(feature = "unstable")]
-fn select_query_format() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
-    let assert = cmd
-        .arg("select")
-        .arg("003@.0,028A{ a <$> (', ' d <*> ' (' c ')' ) }")
-        .arg(data_dir().join("ada.dat"))
-        .assert();
-
-    assert
-        .success()
-        .code(0)
-        .stdout(predicates::ord::eq(
-            "119232022,\"Lovelace, Ada King (of)\"\n",
-        ))
-        .stderr(predicates::str::is_empty());
-
-    let mut cmd = Command::cargo_bin("pica")?;
-    let assert = cmd
-        .arg("select")
-        .arg("003@.0,028R{a <$> (', ' d <*> ' (' v ')') | v in ['Vater', 'Mutter']}")
-        .arg(data_dir().join("ada.dat"))
-        .assert();
-
-    assert
-        .success()
-        .code(0)
-        .stdout(predicates::ord::eq(
-            "119232022,\"Byron, George Gordon Byron (Vater)\"\n\
-            119232022,\"Byron, Anne Isabella Milbanke Byron (Mutter)\"\n"
         ))
         .stderr(predicates::str::is_empty());
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,6 @@ pub enum Error {
     ParseMatcher(ParseMatcherError),
     #[error(transparent)]
     ParsePath(ParsePathError),
-    #[cfg(feature = "unstable")]
     #[error(transparent)]
     ParseFormat(crate::fmt::ParseFormatError),
     #[error(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ pub use error::Error;
 pub use record::{ByteRecord, StringRecord};
 
 mod error;
-#[cfg(feature = "unstable")]
 mod fmt;
 pub mod matcher;
 mod parser;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,7 +14,6 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
-#[cfg(feature = "unstable")]
 pub use crate::fmt::{Format, FormatExt, FormatOptions};
 pub use crate::matcher::field::FieldMatcher;
 pub use crate::matcher::subfield::SubfieldMatcher;

--- a/src/query.rs
+++ b/src/query.rs
@@ -6,7 +6,6 @@ use winnow::combinator::{alt, separated};
 use winnow::{ModalResult, Parser};
 
 use crate::StringRecord;
-#[cfg(feature = "unstable")]
 use crate::fmt::{Format, FormatExt, FormatOptions, parse_format};
 use crate::matcher::MatcherOptions;
 use crate::parser::{parse_string, ws};
@@ -109,7 +108,6 @@ impl<'de> serde::Deserialize<'de> for Query {
 enum Fragment {
     Path(Box<Path>),
     Literal(BString),
-    #[cfg(feature = "unstable")]
     Format(Box<Format>),
 }
 
@@ -123,7 +121,6 @@ impl Fragment {
 
         match self {
             Literal(lit) => Outcome(vec![vec![lit.clone()]]),
-            #[cfg(feature = "unstable")]
             Format(fmt) => Outcome(
                 record
                     .format(fmt, &options.into())
@@ -213,7 +210,6 @@ fn parse_fragment(i: &mut &[u8]) -> ModalResult<Fragment> {
     alt((
         parse_path.map(|path| Fragment::Path(Box::new(path))),
         parse_string.map(|s| Fragment::Literal(s.into())),
-        #[cfg(feature = "unstable")]
         parse_format.map(|format| Fragment::Format(Box::new(format))),
     ))
     .parse_next(i)
@@ -295,7 +291,6 @@ impl From<&QueryOptions> for MatcherOptions {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl From<&QueryOptions> for FormatOptions {
     #[inline]
     fn from(options: &QueryOptions) -> Self {
@@ -682,7 +677,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unstable")]
     fn test_query_format() -> TestResult {
         let data = ada_lovelace();
         let record = ByteRecord::from_bytes(&data)?;


### PR DESCRIPTION
```console
$ pica select '003@{ "https://explore.gnd.network/gnd/" 0 }, 028A{a <$> (", " d <*> " " c) }' goethe.dat ada.dat
https://explore.gnd.network/gnd/118540238,Goethe, Johann Wolfgang von
https://explore.gnd.network/gnd/119232022,Lovelace, Ada King of
```