### PR TITLE
Add option for stripping overread character

### DIFF
--- a/crates/pica-cli/tests/select/format.rs
+++ b/crates/pica-cli/tests/select/format.rs
@@ -1,7 +1,5 @@
 use assert_cmd::Command;
 
-// use assert_fs::TempDir;
-// use assert_fs::prelude::*;
 use crate::prelude::*;
 
 #[test]
@@ -150,6 +148,35 @@ fn format_string_trim() -> TestResult {
         .stdout(predicates::ord::eq(
             "119232022,\"Lovelace, Ada King (of)\"\n",
         ))
+        .stderr(predicates::str::is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn format_strip_overread_char() -> TestResult {
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .args(["select", "021A{?o a }"])
+        .write_stdin(b"021A \x1fa@abc\x1e\n")
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::ord::eq("abc\n"))
+        .stderr(predicates::str::is_empty());
+
+    let mut cmd = Command::cargo_bin("pica")?;
+    let assert = cmd
+        .args(["select", "021A{ a }"])
+        .write_stdin(b"021A \x1fa@abc\x1e\n")
+        .assert();
+
+    assert
+        .success()
+        .code(0)
+        .stdout(predicates::ord::eq("@abc\n"))
         .stderr(predicates::str::is_empty());
 
     Ok(())

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -77,7 +77,7 @@ pub struct FormatOptions {
 impl Default for FormatOptions {
     fn default() -> Self {
         Self {
-            strip_overread_char: true,
+            strip_overread_char: false,
             strsim_threshold: 0.8,
             case_ignore: false,
         }
@@ -297,9 +297,20 @@ struct Modifier {
     /// Whether to remove all whitespaces from the beginning or end of
     /// a fragment or not.
     trim: bool,
+
+    /// Whether to strip the overread character '@' or not.
+    strip_overread_char: bool,
 }
 
 impl Modifier {
+    pub(crate) fn strip_overread_char(
+        &mut self,
+        yes: bool,
+    ) -> &mut Self {
+        self.strip_overread_char = yes;
+        self
+    }
+
     pub(crate) fn lowercase(&mut self, yes: bool) -> &mut Self {
         self.lowercase = yes;
         self
@@ -321,6 +332,10 @@ impl Modifier {
     }
 
     pub(crate) fn modify(&self, value: &mut BString) {
+        if self.strip_overread_char {
+            *value = value.replacen("@", "", 1).into();
+        }
+
         if self.trim {
             *value = BString::from(value.trim());
         }


### PR DESCRIPTION
The `o` modifier specifies whether the overread character (first `@` character) should be removed or not.

```console
$ pica select -s '022A.a' tests/data/DUMP.dat.gz --where '003@.0 == "040993396"'
Die @Räuber

$ pica select -s '022A{?o a }' tests/data/DUMP.dat.gz --where '003@.0 == "040993396"'
Die Räuber
```