### PR TITLE
Optimize frequency command by removing unnecessary clone

### DIFF
--- a/crates/pica-cli/src/commands/frequency.rs
+++ b/crates/pica-cli/src/commands/frequency.rs
@@ -173,14 +173,12 @@ impl Frequency {
                         let outcome = record.query(&query, &options);
                         seen.clear();
 
-                        for key in outcome.clone().into_iter() {
+                        for key in outcome.into_inner() {
                             if key.iter().any(|e| !e.is_empty()) {
-                                if self.unique {
-                                    if seen.contains(&key) {
-                                        continue;
-                                    }
-
-                                    seen.insert(key.clone());
+                                if self.unique
+                                    && !seen.insert(key.clone())
+                                {
+                                    continue;
                                 }
 
                                 *ftable.entry(key).or_insert(0) += 1;


### PR DESCRIPTION
Remove `outcome.clone()` call in the hot path of frequency computation. The outcome is not used after iteration, so we can consume it directly using `into_inner()` instead of cloning the entire data structure.

Also optimize the unique check by using HashSet::insert()'s return value (false when key already exists) instead of separate contains() and insert() calls.