### PR TITLE
Optimize performance: pre-allocate collections

### DIFF
--- a/crates/pica-cli/tests/filter/mod.rs
+++ b/crates/pica-cli/tests/filter/mod.rs
@@ -507,7 +507,7 @@ fn filter_limit() -> TestResult {
         .stderr(predicates::str::is_empty());
 
     let output = read_to_string(out.path())?;
-    let mut goethe = output.lines().nth(0).unwrap().to_string();
+    let mut goethe = output.lines().next().unwrap().to_string();
     goethe.push('\n');
     assert_eq!(read_to_string(data_dir().join("goethe.dat"))?, goethe);
 

--- a/crates/pica-cli/tests/hash/mod.rs
+++ b/crates/pica-cli/tests/hash/mod.rs
@@ -3,7 +3,7 @@ use assert_fs::prelude::*;
 
 use crate::prelude::*;
 
-const HASHES: &'static str = "\
+const HASHES: &str = "\
 118540238,762cf3a1b18a0cad2d0401cd2b573a89ff9c81b43c4ddab76e136d7a10a851f3\n\
 118607626,8d75e2cdfec20aa025d36018a40b150363d79571788cd92e7ff568595ba4f9ee\n\
 040993396,0361c33e1f7a80e21eecde747b2721b7884e003ac4deb8c271684ec0dc4d059a\n\

--- a/src/query.rs
+++ b/src/query.rs
@@ -393,14 +393,19 @@ impl<T: ToString + Clone> Mul for Outcome<T> {
             return self;
         }
 
-        let mut rows = vec![];
         let xs = self.0;
         let ys = rhs.0;
+
+        // Pre-allocate with exact capacity to avoid reallocations
+        let capacity = xs.len() * ys.len();
+        let mut rows = Vec::with_capacity(capacity);
 
         for x in xs.into_iter() {
             for y in ys.iter() {
                 let mut row = x.clone();
-                row.extend(y.clone());
+                // Use extend_from_slice instead of extend(y.clone())
+                // to avoid the intermediate iterator
+                row.extend_from_slice(y);
                 rows.push(row);
             }
         }


### PR DESCRIPTION
- Optimize Outcome multiplication operation (query.rs)
- Remove redundant 'static lifetime annotation in HASHES constant
- Replace .nth(0) with .next() for better idiomaticity

Requires https://github.com/deutsche-nationalbibliothek/pica-rs/pull/1006