### PR TITLE
Fix deprecated Command::cargo_bin usage in tests

### DIFF
--- a/crates/pica-cli/tests/check/datetime.rs
+++ b/crates/pica-cli/tests/check/datetime.rs
@@ -1,4 +1,3 @@
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -18,7 +17,7 @@ fn invalid() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -35,7 +34,7 @@ fn invalid() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -69,7 +68,7 @@ fn message() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -105,7 +104,7 @@ fn offset() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -122,7 +121,7 @@ fn offset() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -156,7 +155,7 @@ fn format() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -173,7 +172,7 @@ fn format() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -208,7 +207,7 @@ fn case_ignore() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset1.to_str().unwrap()])
@@ -237,7 +236,7 @@ fn case_ignore() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset2.to_str().unwrap()])

--- a/crates/pica-cli/tests/check/duplicates.rs
+++ b/crates/pica-cli/tests/check/duplicates.rs
@@ -1,4 +1,3 @@
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -18,7 +17,7 @@ fn check_duplicates_path() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -35,7 +34,7 @@ fn check_duplicates_path() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -68,7 +67,7 @@ fn check_duplicates_query() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -84,7 +83,7 @@ fn check_duplicates_query() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -117,7 +116,7 @@ fn check_duplicates_threshold() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -131,7 +130,7 @@ fn check_duplicates_threshold() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -166,7 +165,7 @@ fn check_duplicates_ignore_case() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -202,7 +201,7 @@ fn check_duplicates_separator() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])

--- a/crates/pica-cli/tests/check/filter.rs
+++ b/crates/pica-cli/tests/check/filter.rs
@@ -1,4 +1,3 @@
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -18,7 +17,7 @@ fn invalid() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -33,7 +32,7 @@ fn invalid() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -66,7 +65,7 @@ fn invert_match() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -81,7 +80,7 @@ fn invert_match() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -114,7 +113,7 @@ fn case_ignore() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -129,7 +128,7 @@ fn case_ignore() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -159,7 +158,7 @@ fn case_ignore() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -172,7 +171,7 @@ fn case_ignore() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])

--- a/crates/pica-cli/tests/check/isni.rs
+++ b/crates/pica-cli/tests/check/isni.rs
@@ -1,4 +1,3 @@
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -18,7 +17,7 @@ fn orcid() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -35,7 +34,7 @@ fn orcid() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -52,7 +51,7 @@ fn orcid() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -67,7 +66,7 @@ fn orcid() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -101,7 +100,7 @@ fn isni() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -118,7 +117,7 @@ fn isni() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -135,7 +134,7 @@ fn isni() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -150,7 +149,7 @@ fn isni() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -165,7 +164,7 @@ fn isni() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -200,7 +199,7 @@ fn prefix() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -217,7 +216,7 @@ fn prefix() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -234,7 +233,7 @@ fn prefix() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -249,7 +248,7 @@ fn prefix() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -264,7 +263,7 @@ fn prefix() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -300,7 +299,7 @@ fn case_ignore() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -317,7 +316,7 @@ fn case_ignore() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])

--- a/crates/pica-cli/tests/check/iso639.rs
+++ b/crates/pica-cli/tests/check/iso639.rs
@@ -1,4 +1,3 @@
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -18,7 +17,7 @@ fn default() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -33,7 +32,7 @@ fn default() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -50,7 +49,7 @@ fn default() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -83,7 +82,7 @@ fn case_ignore() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -98,7 +97,7 @@ fn case_ignore() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])

--- a/crates/pica-cli/tests/check/jelc.rs
+++ b/crates/pica-cli/tests/check/jelc.rs
@@ -1,4 +1,3 @@
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -18,7 +17,7 @@ fn check_jel_default() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -35,7 +34,7 @@ fn check_jel_default() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -69,7 +68,7 @@ fn check_jel_case_ignore() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -86,7 +85,7 @@ fn check_jel_case_ignore() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])

--- a/crates/pica-cli/tests/check/link.rs
+++ b/crates/pica-cli/tests/check/link.rs
@@ -1,4 +1,3 @@
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -19,7 +18,7 @@ fn simple() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["check", "-s"])
         .args(["-R", ruleset.to_str().unwrap()])
@@ -56,7 +55,7 @@ fn path_filter() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["check", "-s"])
         .args(["-R", ruleset.to_str().unwrap()])
@@ -90,7 +89,7 @@ fn condition() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["check", "-s"])
         .args(["-R", ruleset.to_str().unwrap()])

--- a/crates/pica-cli/tests/check/mod.rs
+++ b/crates/pica-cli/tests/check/mod.rs
@@ -1,6 +1,5 @@
 use std::fs::read_to_string;
 
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 use predicates::prelude::PredicateBooleanExt;
@@ -28,7 +27,7 @@ fn check_skip_invalid() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -44,7 +43,7 @@ fn check_skip_invalid() -> TestResult {
             "parse error: invalid record on line 1",
         ));
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["check", "-s"])
         .args(["-R", ruleset.to_str().unwrap()])
@@ -77,7 +76,7 @@ fn check_scope() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -108,7 +107,7 @@ fn check_limit() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["check", "--limit", "1"])
         .args(["-R", ruleset.to_str().unwrap()])
@@ -140,7 +139,7 @@ fn check_where() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -156,7 +155,7 @@ fn check_where() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -191,7 +190,7 @@ fn check_txt_output() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["check", "-s"])
         .args(["-R", ruleset.to_str().unwrap()])
@@ -227,7 +226,7 @@ fn check_tsv_output() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["check", "-s"])
         .args(["-R", ruleset.to_str().unwrap()])
@@ -268,7 +267,7 @@ fn check_termination() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -299,7 +298,7 @@ fn check_termination() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])

--- a/crates/pica-cli/tests/check/unicode.rs
+++ b/crates/pica-cli/tests/check/unicode.rs
@@ -1,4 +1,3 @@
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -17,7 +16,7 @@ fn invalid() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -54,7 +53,7 @@ fn normalization() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])
@@ -84,7 +83,7 @@ fn normalization() -> TestResult {
         )
         .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("check")
         .args(["-R", ruleset.to_str().unwrap()])

--- a/crates/pica-cli/tests/completions/mod.rs
+++ b/crates/pica-cli/tests/completions/mod.rs
@@ -1,4 +1,3 @@
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
@@ -10,7 +9,7 @@ fn completions_bash() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("pica.bash");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("completions")
         .arg("bash")
@@ -32,7 +31,7 @@ fn completions_bash() -> TestResult {
 #[test]
 fn completions_stdout() -> TestResult {
     for shell in ["bash", "zsh", "elvish"] {
-        let mut cmd = Command::cargo_bin("pica")?;
+        let mut cmd = pica_cmd();
         let assert = cmd.arg("completions").arg(shell).assert();
         assert
             .success()
@@ -49,7 +48,7 @@ fn completions_zsh() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("pica.zsh");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("completions")
         .arg("zsh")
@@ -73,7 +72,7 @@ fn completions_elvish() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("elvish.sh");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("completions")
         .arg("elvish")
@@ -97,7 +96,7 @@ fn completions_fish() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("completions.fish");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("completions")
         .arg("fish")
@@ -121,7 +120,7 @@ fn completions_powershell() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("completions.ps1");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("completions")
         .arg("powershell")

--- a/crates/pica-cli/tests/concat/mod.rs
+++ b/crates/pica-cli/tests/concat/mod.rs
@@ -1,6 +1,5 @@
 use std::fs::read_to_string;
 
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
@@ -9,7 +8,7 @@ use crate::prelude::*;
 
 #[test]
 fn single_file_write_stdout() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert =
         cmd.arg("concat").arg(data_dir().join("ada.dat")).assert();
 
@@ -24,7 +23,7 @@ fn single_file_write_stdout() -> TestResult {
 
 #[test]
 fn read_stdin() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("concat")
         .write_stdin(read_to_string(data_dir().join("ada.dat"))?)
@@ -36,7 +35,7 @@ fn read_stdin() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("cat")
         .arg("-")
@@ -49,7 +48,7 @@ fn read_stdin() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["concat", "-s", "-u"])
         .arg(data_dir().join("invalid.dat"))
@@ -69,7 +68,7 @@ fn read_stdin() -> TestResult {
 
 #[test]
 fn single_file_write_file() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.dat");
 
@@ -96,7 +95,7 @@ fn single_file_write_file() -> TestResult {
 
 #[test]
 fn write_gzip() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.dat.gz");
 
@@ -112,7 +111,7 @@ fn write_gzip() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd.arg("concat").arg(out.as_os_str()).assert();
 
     assert
@@ -130,7 +129,7 @@ fn single_file_write_tee() -> TestResult {
     let out = temp_dir.child("out.dat");
     let tee = temp_dir.child("tee.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("concat")
         .args(["--tee", tee.to_str().unwrap()])
@@ -148,7 +147,7 @@ fn single_file_write_tee() -> TestResult {
             .eval(tee.path())
     );
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("concat")
         .args(["--tee", tee.to_str().unwrap()])
@@ -177,7 +176,7 @@ fn single_file_write_tee() -> TestResult {
 
 #[test]
 fn skip_invalid() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("concat")
         .arg("--skip-invalid")
@@ -190,7 +189,7 @@ fn skip_invalid() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["concat", "-s"])
         .arg(data_dir().join("invalid.dat"))
@@ -203,7 +202,7 @@ fn skip_invalid() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("concat")
         .arg(data_dir().join("invalid.dat"))
@@ -219,7 +218,7 @@ fn skip_invalid() -> TestResult {
         ));
 
     // config
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let config = temp_dir.child("pica.toml");
     let filename = config.to_str().unwrap();
@@ -236,7 +235,7 @@ fn skip_invalid() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["-c", config.to_str().unwrap()])
         .arg("concat")
@@ -256,7 +255,7 @@ fn skip_invalid() -> TestResult {
 
 #[test]
 fn unique_by_idn() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let assert = cmd
         .args(["concat", "-u", "--unique-strategy", "idn"])
@@ -277,7 +276,7 @@ fn unique_by_idn() -> TestResult {
 
 #[test]
 fn unique_by_hash() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let assert = cmd
         .args(["concat", "--unique"])
@@ -299,7 +298,7 @@ fn unique_by_hash() -> TestResult {
 
 #[test]
 fn append() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.dat");
 

--- a/crates/pica-cli/tests/config/mod.rs
+++ b/crates/pica-cli/tests/config/mod.rs
@@ -1,6 +1,5 @@
 use std::fs::read_to_string;
 
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
@@ -9,7 +8,7 @@ use crate::prelude::*;
 
 #[test]
 fn set_option() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let config = temp_dir.child("pica.toml");
     let filename = config.to_str().unwrap();
@@ -42,7 +41,7 @@ fn get_option() -> TestResult {
     let config = temp_dir.child("pica.toml");
     let filename = config.to_str().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["--config", filename])
         .args(["config", "skip-invalid"])
@@ -54,7 +53,7 @@ fn get_option() -> TestResult {
         .stdout(predicates::str::contains("false"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["--config", filename])
         .arg("config")
@@ -67,7 +66,7 @@ fn get_option() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["--config", filename])
         .args(["config", "skip-invalid"])
@@ -91,7 +90,7 @@ fn unset_option() -> TestResult {
     let filename = config.to_str().unwrap();
 
     // get (option is not set yet)
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["--config", filename])
         .args(["config", "normalization"])
@@ -104,7 +103,7 @@ fn unset_option() -> TestResult {
         .stderr(predicates::str::is_empty());
 
     // set option
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["--config", filename])
         .arg("config")
@@ -117,7 +116,7 @@ fn unset_option() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["--config", filename])
         .args(["config", "normalization"])
@@ -129,7 +128,7 @@ fn unset_option() -> TestResult {
         .stdout(predicates::str::contains("nfd"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["--config", filename])
         .args(["config", "--unset", "normalization"])
@@ -141,7 +140,7 @@ fn unset_option() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["--config", filename])
         .args(["config", "--get", "normalization"])
@@ -160,7 +159,7 @@ fn unset_option() -> TestResult {
 
 #[test]
 fn invalid_option() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let config = temp_dir.child("pica.toml");
     let filename = config.to_str().unwrap();

--- a/crates/pica-cli/tests/convert/mod.rs
+++ b/crates/pica-cli/tests/convert/mod.rs
@@ -1,6 +1,5 @@
 use std::fs::read_to_string;
 
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
@@ -9,7 +8,7 @@ use super::prelude::*;
 
 #[test]
 fn convert_from_plus_to_xml() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("ada.xml");
 
@@ -39,7 +38,7 @@ fn convert_from_plus_to_xml() -> TestResult {
 
 #[test]
 fn convert_from_plus_to_json() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("ada.json");
 
@@ -65,7 +64,7 @@ fn convert_from_plus_to_json() -> TestResult {
 
 #[test]
 fn convert_from_plus_to_plus() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("ada.dat");
 
@@ -93,7 +92,7 @@ fn convert_from_plus_to_plus() -> TestResult {
 
 #[test]
 fn convert_from_plus_to_plain() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("ada.plain");
 
@@ -123,7 +122,7 @@ fn convert_from_plus_to_plain() -> TestResult {
 
 #[test]
 fn convert_from_plus_to_import() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("ada.import");
 
@@ -151,7 +150,7 @@ fn convert_from_plus_to_import() -> TestResult {
 
 #[test]
 fn convert_from_plus_to_binary() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("ada.bin");
 
@@ -179,7 +178,7 @@ fn convert_from_plus_to_binary() -> TestResult {
 
 #[test]
 fn convert_skip_invalid() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["convert", "-s"])
         .args(["--from", "plus", "--to", "json"])
@@ -192,7 +191,7 @@ fn convert_skip_invalid() -> TestResult {
         .stdout(predicates::ord::eq("[]"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["convert"])
         .args(["--from", "plus", "--to", "json"])

--- a/crates/pica-cli/tests/count/mod.rs
+++ b/crates/pica-cli/tests/count/mod.rs
@@ -1,6 +1,5 @@
 use std::fs::read_to_string;
 
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -8,7 +7,7 @@ use crate::prelude::*;
 
 #[test]
 fn count_write_stdout() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -30,7 +29,7 @@ fn count_write_output() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("counts.csv");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "-o", out.to_str().unwrap()])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -56,7 +55,7 @@ fn count_write_append() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("counts.csv");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--csv"])
         .args(["--where", "002@.0 =^ 'Tp'"])
@@ -70,7 +69,7 @@ fn count_write_append() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--csv", "--append", "--no-header"])
         .args(["--where", "002@.0 =^ 'Ts'"])
@@ -95,7 +94,7 @@ fn count_write_append() -> TestResult {
 
 #[test]
 fn count_write_csv() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--csv"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -114,7 +113,7 @@ fn count_write_csv() -> TestResult {
 
 #[test]
 fn count_write_tsv() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--tsv"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -133,7 +132,7 @@ fn count_write_tsv() -> TestResult {
 
 #[test]
 fn count_write_records() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -150,7 +149,7 @@ fn count_write_records() -> TestResult {
 
 #[test]
 fn count_write_fields() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--fields"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -167,7 +166,7 @@ fn count_write_fields() -> TestResult {
 
 #[test]
 fn count_write_subfields() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--subfields"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -184,7 +183,7 @@ fn count_write_subfields() -> TestResult {
 
 #[test]
 fn count_write_no_header() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--csv", "--no-header"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -196,7 +195,7 @@ fn count_write_no_header() -> TestResult {
         .stdout(predicates::ord::eq("12,1035,3973\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--tsv", "--no-header"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -213,7 +212,7 @@ fn count_write_no_header() -> TestResult {
 
 #[test]
 fn count_where() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .args(["--where", "002@.0 =^ 'Tp'"])
@@ -231,7 +230,7 @@ fn count_where() -> TestResult {
 
 #[test]
 fn count_where_and() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .args(["--where", "002@.0 =^ 'T'"])
@@ -250,7 +249,7 @@ fn count_where_and() -> TestResult {
 
 #[test]
 fn count_where_not() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .args(["--where", "002@.0 =^ 'Tp'"])
@@ -269,7 +268,7 @@ fn count_where_not() -> TestResult {
 
 #[test]
 fn count_where_or() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .args(["--where", "002@.0 =^ 'Tp'"])
@@ -289,7 +288,7 @@ fn count_where_or() -> TestResult {
 #[test]
 fn count_allow() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let allow = temp_dir.child("allow.csv");
     allow.write_str("ppn\n118540238\n118607626\n")?;
@@ -313,7 +312,7 @@ fn count_allow() -> TestResult {
 #[test]
 fn count_deny() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let deny = temp_dir.child("allow.csv");
     deny.write_str("ppn\n118540238\n118607626\n")?;
@@ -337,7 +336,7 @@ fn count_deny() -> TestResult {
 #[test]
 fn count_filter_set_column() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let allow = temp_dir.child("allow.csv");
     allow.write_str("id\n118540238\n118607626\n")?;
@@ -362,7 +361,7 @@ fn count_filter_set_column() -> TestResult {
 #[test]
 fn count_filter_set_source() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let allow = temp_dir.child("allow.csv");
     allow.write_str("bbg\nTpz\nTp1\n")?;
@@ -387,7 +386,7 @@ fn count_filter_set_source() -> TestResult {
 
 #[test]
 fn count_ignore_case() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .args(["-i", "--where", "002@.0 =^ 'tp'"])
@@ -405,7 +404,7 @@ fn count_ignore_case() -> TestResult {
 
 #[test]
 fn count_skip_invalid() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(data_dir().join("invalid.dat"))
@@ -417,7 +416,7 @@ fn count_skip_invalid() -> TestResult {
         .stdout(predicates::ord::eq("0\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "--records"])
         .arg(data_dir().join("invalid.dat"))

--- a/crates/pica-cli/tests/describe/mod.rs
+++ b/crates/pica-cli/tests/describe/mod.rs
@@ -1,6 +1,5 @@
 use std::fs::read_to_string;
 
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -8,7 +7,7 @@ use crate::prelude::*;
 
 #[test]
 fn describe_write_stdout() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["describe", "-s", "-k", "050C"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -28,7 +27,7 @@ fn describe_write_csv() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.csv");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["describe", "-s", "-k", "050C"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -51,7 +50,7 @@ fn describe_write_tsv() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.tsv");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["describe", "-s", "-k", "050C"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -75,7 +74,7 @@ fn describe_write_tsv() -> TestResult {
 
 #[test]
 fn describe_skip_invalid() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("describe")
         .arg(data_dir().join("invalid.dat"))
@@ -97,7 +96,7 @@ fn describe_keep() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.csv");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["describe", "-s", "-k", "002@"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -120,7 +119,7 @@ fn describe_discard() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.csv");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["describe", "-s", "-k", "00[23]@", "-d", "003@"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -146,7 +145,7 @@ fn describe_allow() -> TestResult {
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("ppn\n118540238\n")?;
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["describe", "-s", "-k", "007N"])
         .args(["-A", allow.to_str().unwrap()])
@@ -177,7 +176,7 @@ fn describe_deny() -> TestResult {
     let deny = temp_dir.child("DENY.csv");
     deny.write_str("ppn\n118540238\n")?;
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["describe", "-s", "-k", "007N"])
         .args(["-D", deny.to_str().unwrap()])
@@ -208,7 +207,7 @@ fn describe_filter_set_column() -> TestResult {
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("id\n118540238\n")?;
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["describe", "-s", "-k", "007N"])
         .args(["-A", allow.to_str().unwrap()])
@@ -240,7 +239,7 @@ fn describe_filter_set_source() -> TestResult {
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("gnd_id\n118540238\n")?;
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["describe", "-s", "-k", "007N"])
         .args(["-A", allow.to_str().unwrap()])
@@ -270,7 +269,7 @@ fn describe_where() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.csv");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["describe", "-s", "-k", "007N"])
         .args(["--where", "003@.0 == '118540238'"])
@@ -298,7 +297,7 @@ fn describe_where_and() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.csv");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["describe", "-s", "-k", "007N"])
         .args(["--where", "003@.0 == '118540238'"])
@@ -327,7 +326,7 @@ fn describe_where_or() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.csv");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["describe", "-s", "-k", "007N"])
         .args(["--where", "003@.0 == '118540238'"])
@@ -356,7 +355,7 @@ fn describe_where_not() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.csv");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["describe", "-s", "-k", "007N"])
         .args(["--where", "003@.0 == '118540238'"])

--- a/crates/pica-cli/tests/explode/mod.rs
+++ b/crates/pica-cli/tests/explode/mod.rs
@@ -1,6 +1,5 @@
 use std::fs::read_to_string;
 
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -8,7 +7,7 @@ use super::prelude::*;
 
 #[test]
 fn explode_stdout() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "main"])
         .arg(data_dir().join("ada.dat"))
@@ -26,7 +25,7 @@ fn explode_stdout() -> TestResult {
 
 #[test]
 fn explode_local() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "local"])
         .arg(data_dir().join("COPY.dat.gz"))
@@ -53,7 +52,7 @@ fn explode_local() -> TestResult {
 
 #[test]
 fn explode_copy() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "copy"])
         .arg(data_dir().join("COPY.dat.gz"))
@@ -83,7 +82,7 @@ fn explode_copy() -> TestResult {
 
 #[test]
 fn explode_output() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.dat");
 
@@ -112,7 +111,7 @@ fn explode_gzip() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.dat.gz");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "main"])
         .args(["-o", out.to_str().unwrap()])
@@ -125,7 +124,7 @@ fn explode_gzip() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd.arg("concat").arg(out.as_os_str()).assert();
 
     assert
@@ -135,7 +134,7 @@ fn explode_gzip() -> TestResult {
         .stderr(predicates::str::is_empty());
 
     let out = temp_dir.child("out.dat.gz");
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "--gzip", "main"])
         .args(["-o", out.to_str().unwrap()])
@@ -148,7 +147,7 @@ fn explode_gzip() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd.arg("concat").arg(out.as_os_str()).assert();
 
     assert
@@ -163,7 +162,7 @@ fn explode_gzip() -> TestResult {
 
 #[test]
 fn explode_limit() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "copy"])
         .args(["--limit", "2"])
@@ -185,7 +184,7 @@ fn explode_limit() -> TestResult {
         .stdout(predicates::ord::eq(output))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "copy"])
         .args(["--limit", "1"])
@@ -203,7 +202,7 @@ fn explode_limit() -> TestResult {
         .stdout(predicates::ord::eq(output))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "copy"])
         .args(["--limit", "0"])
@@ -234,7 +233,7 @@ fn explode_limit() -> TestResult {
 
 #[test]
 fn explode_skip_invalid() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "-s", "main"])
         .arg(data_dir().join("invalid.dat"))
@@ -246,7 +245,7 @@ fn explode_skip_invalid() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "main"])
         .arg(data_dir().join("invalid.dat"))
@@ -260,7 +259,7 @@ fn explode_skip_invalid() -> TestResult {
             "parse error: invalid record on line 1",
         ));
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "-s", "main"])
         .arg(data_dir().join("invalid.dat"))
@@ -279,7 +278,7 @@ fn explode_skip_invalid() -> TestResult {
 
 #[test]
 fn explode_where() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "copy"])
         .args(["--where", "101@.a == '1'"])
@@ -306,7 +305,7 @@ fn explode_where() -> TestResult {
 
 #[test]
 fn explode_where_and() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "copy"])
         .args(["--where", "101@.a == '1'"])
@@ -334,7 +333,7 @@ fn explode_where_and() -> TestResult {
 
 #[test]
 fn explode_where_and_not() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "copy"])
         .args(["--where", "101@.a == '1'"])
@@ -359,7 +358,7 @@ fn explode_where_and_not() -> TestResult {
 
 #[test]
 fn explode_where_not() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "copy"])
         .args(["--where", "101@.a == '1'"])
@@ -383,7 +382,7 @@ fn explode_where_not() -> TestResult {
 
 #[test]
 fn explode_where_or() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "copy"])
         .args(["--where", "203@/*.0 == '0123456789'"])
@@ -411,7 +410,7 @@ fn explode_where_or() -> TestResult {
 
 #[test]
 fn explode_allow() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("ppn\n123456789\n")?;
@@ -437,7 +436,7 @@ fn explode_allow() -> TestResult {
 
 #[test]
 fn explode_deny() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let deny = temp_dir.child("ALLOW.csv");
     deny.write_str("ppn\n123456789\n")?;
@@ -459,7 +458,7 @@ fn explode_deny() -> TestResult {
 
 #[test]
 fn explode_filter_set_column() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("id\n123456789\n")?;
@@ -486,7 +485,7 @@ fn explode_filter_set_column() -> TestResult {
 
 #[test]
 fn explode_filter_set_source() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("eln\n345678901\n")?;
@@ -513,7 +512,7 @@ fn explode_filter_set_source() -> TestResult {
 
 #[test]
 fn explode_keep() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "local"])
         .args(["--keep", "003@,101@,203@/*"])
@@ -539,7 +538,7 @@ fn explode_keep() -> TestResult {
 
 #[test]
 fn explode_discard() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["explode", "local"])
         .args(["--discard", "002@"])

--- a/crates/pica-cli/tests/filter/cardinality.rs
+++ b/crates/pica-cli/tests/filter/cardinality.rs
@@ -1,10 +1,8 @@
-use assert_cmd::Command;
-
 use crate::prelude::*;
 
 #[test]
 fn cardinality_field_eq() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "#003@ == 1"])
         .arg(data_dir().join("ada.dat"))
@@ -16,7 +14,7 @@ fn cardinality_field_eq() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "#003@ == 0"])
         .arg(data_dir().join("ada.dat"))
@@ -28,7 +26,7 @@ fn cardinality_field_eq() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "#065R{ 9? && 4 == 'orts'} == 1"])
         .arg(data_dir().join("ada.dat"))
@@ -45,7 +43,7 @@ fn cardinality_field_eq() -> TestResult {
 
 #[test]
 fn cardinality_subfield_eq() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@{ #0 == 1 }"])
         .arg(data_dir().join("ada.dat"))
@@ -57,7 +55,7 @@ fn cardinality_subfield_eq() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@{ #0 == 2 }"])
         .arg(data_dir().join("ada.dat"))
@@ -74,7 +72,7 @@ fn cardinality_subfield_eq() -> TestResult {
 
 #[test]
 fn cardinality_field_ne() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "#003@ != 2"])
         .arg(data_dir().join("ada.dat"))
@@ -86,7 +84,7 @@ fn cardinality_field_ne() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "#003@ != 1"])
         .arg(data_dir().join("ada.dat"))
@@ -103,7 +101,7 @@ fn cardinality_field_ne() -> TestResult {
 
 #[test]
 fn cardinality_subfield_ne() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@{ #0 != 0 }"])
         .arg(data_dir().join("ada.dat"))
@@ -115,7 +113,7 @@ fn cardinality_subfield_ne() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@{ #0 != 1 }"])
         .arg(data_dir().join("ada.dat"))
@@ -132,7 +130,7 @@ fn cardinality_subfield_ne() -> TestResult {
 
 #[test]
 fn cardinality_field_gt() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "#028@ > 5"])
         .arg(data_dir().join("ada.dat"))
@@ -144,7 +142,7 @@ fn cardinality_field_gt() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "#028@ > 100"])
         .arg(data_dir().join("ada.dat"))
@@ -161,7 +159,7 @@ fn cardinality_field_gt() -> TestResult {
 
 #[test]
 fn cardinality_subfield_gt() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "042A{ #a >  1 }"])
         .arg(data_dir().join("ada.dat"))
@@ -173,7 +171,7 @@ fn cardinality_subfield_gt() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "042A{ #a >  3 }"])
         .arg(data_dir().join("ada.dat"))
@@ -190,7 +188,7 @@ fn cardinality_subfield_gt() -> TestResult {
 
 #[test]
 fn cardinality_field_ge() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "#028@ >= 5"])
         .arg(data_dir().join("ada.dat"))
@@ -202,7 +200,7 @@ fn cardinality_field_ge() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "#028@ >= 100"])
         .arg(data_dir().join("ada.dat"))
@@ -219,7 +217,7 @@ fn cardinality_field_ge() -> TestResult {
 
 #[test]
 fn cardinality_subfield_ge() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "042A{ #a >=  1 }"])
         .arg(data_dir().join("ada.dat"))
@@ -231,7 +229,7 @@ fn cardinality_subfield_ge() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "042A{ #a >=  3 }"])
         .arg(data_dir().join("ada.dat"))
@@ -248,7 +246,7 @@ fn cardinality_subfield_ge() -> TestResult {
 
 #[test]
 fn cardinality_field_lt() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "#028@ < 100"])
         .arg(data_dir().join("ada.dat"))
@@ -260,7 +258,7 @@ fn cardinality_field_lt() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "#028@ < 5"])
         .arg(data_dir().join("ada.dat"))
@@ -277,7 +275,7 @@ fn cardinality_field_lt() -> TestResult {
 
 #[test]
 fn cardinality_subfield_lt() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "042A{ #a <  100 }"])
         .arg(data_dir().join("ada.dat"))
@@ -289,7 +287,7 @@ fn cardinality_subfield_lt() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "042A{ #a <  2 }"])
         .arg(data_dir().join("ada.dat"))
@@ -306,7 +304,7 @@ fn cardinality_subfield_lt() -> TestResult {
 
 #[test]
 fn cardinality_field_le() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "#028@ <= 100"])
         .arg(data_dir().join("ada.dat"))
@@ -318,7 +316,7 @@ fn cardinality_field_le() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "#028@ <= 5"])
         .arg(data_dir().join("ada.dat"))
@@ -335,7 +333,7 @@ fn cardinality_field_le() -> TestResult {
 
 #[test]
 fn cardinality_subfield_le() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "042A{ #a <=  100 }"])
         .arg(data_dir().join("ada.dat"))
@@ -347,7 +345,7 @@ fn cardinality_subfield_le() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "042A{ #a <=  1 }"])
         .arg(data_dir().join("ada.dat"))

--- a/crates/pica-cli/tests/filter/connectives.rs
+++ b/crates/pica-cli/tests/filter/connectives.rs
@@ -1,10 +1,8 @@
-use assert_cmd::Command;
-
 use crate::prelude::*;
 
 #[test]
 fn and_connective_field() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@.0 == '119232022' && 002@.0 == 'Tp1'"])
         .arg(data_dir().join("ada.dat"))
@@ -16,7 +14,7 @@ fn and_connective_field() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("filter")
         .arg("060R.a == '1815' && 060R.b == '1852' && 060R.4 == 'datl'")
@@ -29,7 +27,7 @@ fn and_connective_field() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@.0 == '119232022' && 002@.0 == 'Tpz'"])
         .arg(data_dir().join("ada.dat"))
@@ -46,7 +44,7 @@ fn and_connective_field() -> TestResult {
 
 #[test]
 fn and_connective_subfield() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "065R{ 9 == '040743357' && 4 == 'orts' }"])
         .arg(data_dir().join("ada.dat"))
@@ -58,7 +56,7 @@ fn and_connective_subfield() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "065R{ 9 == '040743357' && 4 == 'ortw' }"])
         .arg(data_dir().join("ada.dat"))
@@ -75,7 +73,7 @@ fn and_connective_subfield() -> TestResult {
 
 #[test]
 fn or_connective_field() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@.0 == '118540238' || 002@.0 == 'Tp1'"])
         .arg(data_dir().join("ada.dat"))
@@ -87,7 +85,7 @@ fn or_connective_field() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("filter")
         .arg("060R.a == '1816' || 060R.b == '1852' || 060R.4 == 'datx'")
@@ -100,7 +98,7 @@ fn or_connective_field() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@.0 == '119232022' && 002@.0 == 'Tpz'"])
         .arg(data_dir().join("ada.dat"))
@@ -117,7 +115,7 @@ fn or_connective_field() -> TestResult {
 
 #[test]
 fn or_connective_subfield() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "065R{ 9 == '040743357' || 4 == 'orts' }"])
         .arg(data_dir().join("ada.dat"))
@@ -129,7 +127,7 @@ fn or_connective_subfield() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "065R{ 9 == '118540238' || 4 == 'ortw' }"])
         .arg(data_dir().join("ada.dat"))
@@ -146,7 +144,7 @@ fn or_connective_subfield() -> TestResult {
 
 #[test]
 fn xor_connective_field() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@.0 == '118540238' XOR 002@.0 == 'Tp1'"])
         .arg(data_dir().join("ada.dat"))
@@ -158,7 +156,7 @@ fn xor_connective_field() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("filter")
         .arg("060R.a == '1815' ^ 060R.b == '1852' ^ 060R.4 == 'datx'")
@@ -171,7 +169,7 @@ fn xor_connective_field() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@.0 == '118540238' XOR 002@.0 == 'Tpz'"])
         .arg(data_dir().join("ada.dat"))
@@ -188,7 +186,7 @@ fn xor_connective_field() -> TestResult {
 
 #[test]
 fn xor_connective_subfield() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "065R{ 9 == '040743357' XOR 4 == 'orts' }"])
         .arg(data_dir().join("ada.dat"))
@@ -200,7 +198,7 @@ fn xor_connective_subfield() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "065R{ 9 == '118540238' XOR 4 == 'ortw' }"])
         .arg(data_dir().join("ada.dat"))

--- a/crates/pica-cli/tests/filter/contains.rs
+++ b/crates/pica-cli/tests/filter/contains.rs
@@ -1,10 +1,8 @@
-use assert_cmd::Command;
-
 use crate::prelude::*;
 
 #[test]
 fn contains_substring() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028@.d =? 'August'"])
         .arg(data_dir().join("ada.dat"))
@@ -16,7 +14,7 @@ fn contains_substring() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028@.d =? 'November'"])
         .arg(data_dir().join("ada.dat"))
@@ -33,7 +31,7 @@ fn contains_substring() -> TestResult {
 
 #[test]
 fn contains_case_ignore() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i", "028@.d =? 'august'"])
         .arg(data_dir().join("ada.dat"))
@@ -45,7 +43,7 @@ fn contains_case_ignore() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i", "028@.d =? 'november'"])
         .arg(data_dir().join("ada.dat"))
@@ -62,7 +60,7 @@ fn contains_case_ignore() -> TestResult {
 
 #[test]
 fn contains_set() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028@.d =? ['September', 'August']"])
         .arg(data_dir().join("ada.dat"))
@@ -74,7 +72,7 @@ fn contains_set() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028@.d =? ['Oktober', 'November']"])
         .arg(data_dir().join("ada.dat"))
@@ -91,7 +89,7 @@ fn contains_set() -> TestResult {
 
 #[test]
 fn contains_set_case_ignore() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i", "028@.d =? ['september', 'august']"])
         .arg(data_dir().join("ada.dat"))
@@ -103,7 +101,7 @@ fn contains_set_case_ignore() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i", "028@.d =? ['oktober', 'november']"])
         .arg(data_dir().join("ada.dat"))
@@ -120,7 +118,7 @@ fn contains_set_case_ignore() -> TestResult {
 
 #[test]
 fn contains_set_quantifier() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028@{ ANY d =? ['eptemb', 'gust'] }"])
         .arg(data_dir().join("ada.dat"))
@@ -132,7 +130,7 @@ fn contains_set_quantifier() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028@{ ANY d =? ['tobe', 'ovemb'] }"])
         .arg(data_dir().join("ada.dat"))
@@ -144,7 +142,7 @@ fn contains_set_quantifier() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028@{ ALL [ad] =? ['b', 'a'] }"])
         .arg(data_dir().join("ada.dat"))
@@ -156,7 +154,7 @@ fn contains_set_quantifier() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028@{ ALL [ad] =? ['x', 'y'] }"])
         .arg(data_dir().join("ada.dat"))
@@ -173,7 +171,7 @@ fn contains_set_quantifier() -> TestResult {
 
 #[test]
 fn contains_empty_string() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028@.d =? ''"])
         .arg(data_dir().join("ada.dat"))
@@ -185,7 +183,7 @@ fn contains_empty_string() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028@.d =? ['Oktober', 'November', '']"])
         .arg(data_dir().join("ada.dat"))

--- a/crates/pica-cli/tests/filter/exists.rs
+++ b/crates/pica-cli/tests/filter/exists.rs
@@ -1,10 +1,8 @@
-use assert_cmd::Command;
-
 use crate::prelude::*;
 
 #[test]
 fn field_exists() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@?"])
         .arg(data_dir().join("ada.dat"))
@@ -16,7 +14,7 @@ fn field_exists() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ALL 028[A@].d?"])
         .arg(data_dir().join("ada.dat"))
@@ -28,7 +26,7 @@ fn field_exists() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "012A?"])
         .arg(data_dir().join("ada.dat"))
@@ -40,7 +38,7 @@ fn field_exists() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ANY 028[A@].d?"])
         .arg(data_dir().join("ada.dat"))
@@ -52,7 +50,7 @@ fn field_exists() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ALL 028[A@].c?"])
         .arg(data_dir().join("ada.dat"))
@@ -69,7 +67,7 @@ fn field_exists() -> TestResult {
 
 #[test]
 fn subfield_exists() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@.0?"])
         .arg(data_dir().join("ada.dat"))
@@ -81,7 +79,7 @@ fn subfield_exists() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@{ 0? }"])
         .arg(data_dir().join("ada.dat"))
@@ -93,7 +91,7 @@ fn subfield_exists() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "012A.a?"])
         .arg(data_dir().join("ada.dat"))
@@ -105,7 +103,7 @@ fn subfield_exists() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028A.P?"])
         .arg(data_dir().join("ada.dat"))

--- a/crates/pica-cli/tests/filter/filter_set.rs
+++ b/crates/pica-cli/tests/filter/filter_set.rs
@@ -1,4 +1,3 @@
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -6,7 +5,7 @@ use crate::prelude::*;
 
 #[test]
 fn allow_list_ppn() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("ppn\n118540238").unwrap();
@@ -30,7 +29,7 @@ fn allow_list_ppn() -> TestResult {
 
 #[test]
 fn allow_list_idn() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("idn\n118540238").unwrap();
@@ -54,7 +53,7 @@ fn allow_list_idn() -> TestResult {
 
 #[test]
 fn allow_list_column() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("xyz\n118540238").unwrap();
@@ -79,7 +78,7 @@ fn allow_list_column() -> TestResult {
 
 #[test]
 fn allow_list_source() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("wd_id\nQ5879").unwrap();
@@ -105,7 +104,7 @@ fn allow_list_source() -> TestResult {
 
 #[test]
 fn allow_list_mulval() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let allow = temp_dir.child("DENY.csv");
     allow.write_str("code\nx\nf").unwrap();
@@ -126,7 +125,7 @@ fn allow_list_mulval() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let allow = temp_dir.child("DENY.csv");
     allow.write_str("code\nx\ny").unwrap();
@@ -150,7 +149,7 @@ fn allow_list_mulval() -> TestResult {
 
 #[test]
 fn allow_list_empty() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("ppn").unwrap();
@@ -172,7 +171,7 @@ fn allow_list_empty() -> TestResult {
 
 #[test]
 fn deny_list_ppn() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let deny = temp_dir.child("DENY.csv");
     deny.write_str("ppn\n118540238").unwrap();
@@ -195,7 +194,7 @@ fn deny_list_ppn() -> TestResult {
 
 #[test]
 fn deny_list_idn() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let deny = temp_dir.child("DENY.csv");
     deny.write_str("idn\n118540238").unwrap();
@@ -218,7 +217,7 @@ fn deny_list_idn() -> TestResult {
 
 #[test]
 fn deny_list_column() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let deny = temp_dir.child("DENY.csv");
     deny.write_str("xyz\n118540238").unwrap();
@@ -242,7 +241,7 @@ fn deny_list_column() -> TestResult {
 
 #[test]
 fn deny_list_source() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let deny = temp_dir.child("DENY.csv");
     deny.write_str("isni\n0000 0001 2099 9104").unwrap();
@@ -267,7 +266,7 @@ fn deny_list_source() -> TestResult {
 
 #[test]
 fn deny_list_mulval() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let deny = temp_dir.child("DENY.csv");
     deny.write_str("code\nx\nf").unwrap();
@@ -286,7 +285,7 @@ fn deny_list_mulval() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let deny = temp_dir.child("DENY.csv");
     deny.write_str("code\nx\ny").unwrap();
@@ -312,7 +311,7 @@ fn deny_list_mulval() -> TestResult {
 
 #[test]
 fn deny_list_empty() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.dat");
 
@@ -332,7 +331,7 @@ fn deny_list_empty() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(out.to_str().unwrap())

--- a/crates/pica-cli/tests/filter/in.rs
+++ b/crates/pica-cli/tests/filter/in.rs
@@ -1,10 +1,8 @@
-use assert_cmd::Command;
-
 use crate::prelude::*;
 
 #[test]
 fn r#in() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 in ['Tpz', 'Tp1']"])
         .arg(data_dir().join("ada.dat"))
@@ -16,7 +14,7 @@ fn r#in() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@{ 0 in ['Tpz', 'Tp1'] }"])
         .arg(data_dir().join("ada.dat"))
@@ -28,7 +26,7 @@ fn r#in() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 in ['Tpz', 'Ts1']"])
         .arg(data_dir().join("ada.dat"))
@@ -45,7 +43,7 @@ fn r#in() -> TestResult {
 
 #[test]
 fn not_in() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 not in ['Tsz', 'Tpz']"])
         .arg(data_dir().join("ada.dat"))
@@ -57,7 +55,7 @@ fn not_in() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@{ 0 not in ['Tsz', 'Ts1'] }"])
         .arg(data_dir().join("ada.dat"))
@@ -69,7 +67,7 @@ fn not_in() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 not in ['Tpz', 'Tp1']"])
         .arg(data_dir().join("ada.dat"))

--- a/crates/pica-cli/tests/filter/mod.rs
+++ b/crates/pica-cli/tests/filter/mod.rs
@@ -1,6 +1,5 @@
 use std::fs::read_to_string;
 
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
@@ -19,7 +18,7 @@ mod relation;
 
 #[test]
 fn filter_stdout() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-s", "003@.0 == '118540238'"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -38,7 +37,7 @@ fn filter_stdout() -> TestResult {
 
 #[test]
 fn filter_stdin() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@.0 == '118540238'"])
         .write_stdin(read_to_string(data_dir().join("goethe.dat"))?)
@@ -52,7 +51,7 @@ fn filter_stdin() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@.0 == '118540238'", "-"])
         .write_stdin(read_to_string(data_dir().join("goethe.dat"))?)
@@ -66,7 +65,7 @@ fn filter_stdin() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-s", "003@.0 == '118540238'"])
         .arg(data_dir().join("ada.dat"))
@@ -88,7 +87,7 @@ fn filter_stdin() -> TestResult {
 
 #[test]
 fn filter_output() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.dat");
 
@@ -115,7 +114,7 @@ fn filter_output() -> TestResult {
 
 #[test]
 fn filter_skip_invalid() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@?"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -129,7 +128,7 @@ fn filter_skip_invalid() -> TestResult {
             "parse error: invalid record on line 12",
         ));
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-s", "003@?"])
         .arg(data_dir().join("invalid.dat"))
@@ -146,7 +145,7 @@ fn filter_skip_invalid() -> TestResult {
 
 #[test]
 fn filter_invert_match() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-v", "003@.0 == '040379442'"])
         .arg(data_dir().join("math.dat.gz"))
@@ -164,7 +163,7 @@ fn filter_invert_match() -> TestResult {
 
 #[test]
 fn filter_ignore_case() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i", "002@.0 == 'TP1'"])
         .arg(data_dir().join("math.dat.gz"))
@@ -177,7 +176,7 @@ fn filter_ignore_case() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 == 'TP1'"])
         .arg(data_dir().join("math.dat.gz"))
@@ -195,7 +194,7 @@ fn filter_ignore_case() -> TestResult {
 
 #[test]
 fn filter_strsim_threshold() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028A.a =* 'Lovelaca'"])
         .args(["--strsim-threshold", "75"])
@@ -209,7 +208,7 @@ fn filter_strsim_threshold() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028A.a =* 'Lovelaca'"])
         .args(["--strsim-threshold", "90"])
@@ -228,7 +227,7 @@ fn filter_strsim_threshold() -> TestResult {
 
 #[test]
 fn filter_keep() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-s", "003@.0 == '118540238'"])
         .args(["--keep", "003@, 002@"])
@@ -248,7 +247,7 @@ fn filter_keep() -> TestResult {
 
 #[test]
 fn filter_discard() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-s", "003@.0 == '118540238'"])
         .args(["--discard", "002@,012A/*"])
@@ -268,7 +267,7 @@ fn filter_discard() -> TestResult {
 
 #[test]
 fn filter_expr_file() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
 
     let expr_file = temp_dir.child("expr.txt");
@@ -295,7 +294,7 @@ fn filter_expr_file() -> TestResult {
 #[test]
 fn filter_allow() -> TestResult {
     // IDN
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let allow = temp_dir.child("allow.csv");
     allow.write_str("idn\n118540238").unwrap();
@@ -316,7 +315,7 @@ fn filter_allow() -> TestResult {
     temp_dir.close().unwrap();
 
     // PPN
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let allow = temp_dir.child("allow.csv");
     allow.write_str("idn\n118540238").unwrap();
@@ -337,7 +336,7 @@ fn filter_allow() -> TestResult {
     temp_dir.close().unwrap();
 
     // PPN+IDN
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let allow = temp_dir.child("allow.csv");
     allow.write_str("idn,ppn\n118607626,118540238").unwrap();
@@ -358,7 +357,7 @@ fn filter_allow() -> TestResult {
     temp_dir.close().unwrap();
 
     // empty allow list
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let allow = temp_dir.child("allow.csv");
     allow.write_str("idn\n").unwrap();
@@ -382,7 +381,7 @@ fn filter_allow() -> TestResult {
 #[test]
 fn filter_deny() -> TestResult {
     // IDN
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let deny = temp_dir.child("deny.csv");
     deny.write_str(
@@ -417,7 +416,7 @@ fn filter_deny() -> TestResult {
     temp_dir.close().unwrap();
 
     // PPN
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let deny = temp_dir.child("deny.csv");
     deny.write_str(
@@ -452,7 +451,7 @@ fn filter_deny() -> TestResult {
     temp_dir.close().unwrap();
 
     // empty deny list
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let deny = temp_dir.child("deny.csv");
     deny.write_str("idn\n").unwrap();
@@ -475,7 +474,7 @@ fn filter_deny() -> TestResult {
 
 #[test]
 fn filter_limit() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-s", "003@?"])
         .args(["--limit", "1"])
@@ -490,7 +489,7 @@ fn filter_limit() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.dat");
 
@@ -522,7 +521,7 @@ fn filter_limit() -> TestResult {
 
 #[test]
 fn filter_and() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-s", "003@.0 == '118540238'"])
         .args(["--and", "002@.0 == 'Tpz'"])
@@ -542,7 +541,7 @@ fn filter_and() -> TestResult {
 
 #[test]
 fn filter_and_not() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-s", "003@.0 == '118540238'"])
         .args(["--and", "002@.0 == 'Tpz'"])
@@ -563,7 +562,7 @@ fn filter_and_not() -> TestResult {
 
 #[test]
 fn filter_not() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-s", "003@.0 == '118540238'"])
         .args(["--not", "002@.0 == 'Tp1'"])
@@ -583,7 +582,7 @@ fn filter_not() -> TestResult {
 
 #[test]
 fn filter_or() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-s", "002@.0 == 'Tuz'"])
         .args(["--or", "003@.0 == '118540238'"])
@@ -604,7 +603,7 @@ fn filter_or() -> TestResult {
 #[test]
 fn filter_gzip() -> TestResult {
     // Flag
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.dat.gz");
 
@@ -620,7 +619,7 @@ fn filter_gzip() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0"])
         .arg(out.to_str().unwrap())
@@ -635,7 +634,7 @@ fn filter_gzip() -> TestResult {
     temp_dir.close().unwrap();
 
     // Filename
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.dat.gz");
 
@@ -651,7 +650,7 @@ fn filter_gzip() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0"])
         .arg(out.to_str().unwrap())
@@ -670,7 +669,7 @@ fn filter_gzip() -> TestResult {
 #[test]
 fn filter_append() -> TestResult {
     // Flag
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.dat");
 
@@ -686,7 +685,7 @@ fn filter_append() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-s", "003@?", "--append"])
         .args(["-o", out.to_str().unwrap()])
@@ -699,7 +698,7 @@ fn filter_append() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0"])
         .arg(out.to_str().unwrap())
@@ -717,7 +716,7 @@ fn filter_append() -> TestResult {
 
 #[test]
 fn filter_tee() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let tee = temp_dir.child("tee.dat");
 
@@ -747,7 +746,7 @@ fn filter_tee() -> TestResult {
 /// https://github.com/deutsche-nationalbibliothek/pica-rs/issues/907
 #[test]
 fn filter_no_ppn() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let data = "036E/00 \x1faSpringer-Lehrbuch\x1e036E/01 \x1faSpringer-Link\x1fpBücher\x1e\n";
     let assert =

--- a/crates/pica-cli/tests/filter/regex.rs
+++ b/crates/pica-cli/tests/filter/regex.rs
@@ -1,10 +1,8 @@
-use assert_cmd::Command;
-
 use crate::prelude::*;
 
 #[test]
 fn regex() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 =~ '^T[bfgpsu][1-3z]$'"])
         .arg(data_dir().join("ada.dat"))
@@ -16,7 +14,7 @@ fn regex() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 =~ '^T[bfgpsu][23z]$'"])
         .arg(data_dir().join("ada.dat"))
@@ -28,7 +26,7 @@ fn regex() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "042A{ ALL a =~ '.*p$' }"])
         .arg(data_dir().join("ada.dat"))
@@ -40,7 +38,7 @@ fn regex() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "008A{ ALL a =~ '^[sz]$' }"])
         .arg(data_dir().join("ada.dat"))
@@ -52,7 +50,7 @@ fn regex() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i", "002@.0 =~ '^t[BFGPSU][1-3Z]$'"])
         .arg(data_dir().join("ada.dat"))
@@ -69,7 +67,7 @@ fn regex() -> TestResult {
 
 #[test]
 fn regex_inverted() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 !~ '^O(af|lfo)$'"])
         .arg(data_dir().join("ada.dat"))
@@ -81,7 +79,7 @@ fn regex_inverted() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i", "002@.0 !~ '^olfo'"])
         .arg(data_dir().join("ada.dat"))

--- a/crates/pica-cli/tests/filter/regex_set.rs
+++ b/crates/pica-cli/tests/filter/regex_set.rs
@@ -1,10 +1,8 @@
-use assert_cmd::Command;
-
 use crate::prelude::*;
 
 #[test]
 fn regex_set() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 =~ ['^T[bfg][1-3z]$', '^Tp[1z]$']"])
         .arg(data_dir().join("ada.dat"))
@@ -16,7 +14,7 @@ fn regex_set() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 =~ ['^T[bfg][1-3z]$', '^Tp[23z]$']"])
         .arg(data_dir().join("ada.dat"))
@@ -28,7 +26,7 @@ fn regex_set() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i"])
         .arg("002@.0 =~ ['^t[BFG][1-3z]$', '^tP[1Z]$']")
@@ -41,7 +39,7 @@ fn regex_set() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("filter")
         .arg("042A{ ALL a =~ ['30p', '5p$'] }")
@@ -54,7 +52,7 @@ fn regex_set() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("filter")
         .arg("042A{ ALL a =~ ['30p', 'p$'] }")
@@ -72,7 +70,7 @@ fn regex_set() -> TestResult {
 
 #[test]
 fn regex_set_inverted() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 !~ ['^T[bfg][1-3z]$', '^Tp[1z]$']"])
         .arg(data_dir().join("ada.dat"))
@@ -84,7 +82,7 @@ fn regex_set_inverted() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 !~ ['^T[bfg][1-3z]$', '^Tp[23z]$']"])
         .arg(data_dir().join("ada.dat"))
@@ -96,7 +94,7 @@ fn regex_set_inverted() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i"])
         .arg("002@.0 !~ ['^t[BFG][1-3z]$', '^tP[1Z]$']")

--- a/crates/pica-cli/tests/filter/relation.rs
+++ b/crates/pica-cli/tests/filter/relation.rs
@@ -1,10 +1,8 @@
-use assert_cmd::Command;
-
 use crate::prelude::*;
 
 #[test]
 fn relation_eq() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@.0 == '119232022'"])
         .arg(data_dir().join("ada.dat"))
@@ -16,7 +14,7 @@ fn relation_eq() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@{ 0 == '119232022' }"])
         .arg(data_dir().join("ada.dat"))
@@ -28,7 +26,7 @@ fn relation_eq() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ANY 028@.a == 'Lovelace'"])
         .arg(data_dir().join("ada.dat"))
@@ -40,7 +38,7 @@ fn relation_eq() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ALL 028@.a == 'Lovelace'"])
         .arg(data_dir().join("ada.dat"))
@@ -52,7 +50,7 @@ fn relation_eq() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i", "028@.a == 'LOVELACE'"])
         .arg(data_dir().join("ada.dat"))
@@ -68,7 +66,7 @@ fn relation_eq() -> TestResult {
 
 #[test]
 fn relation_ne() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@.0 != '118540238'"])
         .arg(data_dir().join("ada.dat"))
@@ -80,7 +78,7 @@ fn relation_ne() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "003@{ 0 != '118540238' }"])
         .arg(data_dir().join("ada.dat"))
@@ -92,7 +90,7 @@ fn relation_ne() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ANY 028@.a != 'Lovelace'"])
         .arg(data_dir().join("ada.dat"))
@@ -104,7 +102,7 @@ fn relation_ne() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ALL 028@.a != 'Lovelace'"])
         .arg(data_dir().join("ada.dat"))
@@ -116,7 +114,7 @@ fn relation_ne() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i", "ALL 028@.a != 'LOVELACE'"])
         .arg(data_dir().join("ada.dat"))
@@ -133,7 +131,7 @@ fn relation_ne() -> TestResult {
 
 #[test]
 fn relation_starts_with() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 =^ 'Tp'"])
         .arg(data_dir().join("ada.dat"))
@@ -145,7 +143,7 @@ fn relation_starts_with() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@{ 0 =^ 'Tp' }"])
         .arg(data_dir().join("ada.dat"))
@@ -157,7 +155,7 @@ fn relation_starts_with() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ANY 028@.a =^ 'Love'"])
         .arg(data_dir().join("ada.dat"))
@@ -169,7 +167,7 @@ fn relation_starts_with() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ALL 028@.a =^ 'Love'"])
         .arg(data_dir().join("ada.dat"))
@@ -181,7 +179,7 @@ fn relation_starts_with() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i", "028@.a =^ 'LOVE'"])
         .arg(data_dir().join("ada.dat"))
@@ -198,7 +196,7 @@ fn relation_starts_with() -> TestResult {
 
 #[test]
 fn relation_starts_not_with() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 !^ 'Ts'"])
         .arg(data_dir().join("ada.dat"))
@@ -210,7 +208,7 @@ fn relation_starts_not_with() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@{ 0 !^ 'Ts' }"])
         .arg(data_dir().join("ada.dat"))
@@ -222,7 +220,7 @@ fn relation_starts_not_with() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ANY 028@.a !^ 'Love'"])
         .arg(data_dir().join("ada.dat"))
@@ -234,7 +232,7 @@ fn relation_starts_not_with() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ALL 028@.a =^ 'Hate'"])
         .arg(data_dir().join("ada.dat"))
@@ -251,7 +249,7 @@ fn relation_starts_not_with() -> TestResult {
 
 #[test]
 fn relation_ends_with() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 =$ 'p1'"])
         .arg(data_dir().join("ada.dat"))
@@ -263,7 +261,7 @@ fn relation_ends_with() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@{ 0 =$ 'p1' }"])
         .arg(data_dir().join("ada.dat"))
@@ -275,7 +273,7 @@ fn relation_ends_with() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ANY 028@.a =$ 'lace'"])
         .arg(data_dir().join("ada.dat"))
@@ -287,7 +285,7 @@ fn relation_ends_with() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ALL 028@.a =$ 'lace'"])
         .arg(data_dir().join("ada.dat"))
@@ -299,7 +297,7 @@ fn relation_ends_with() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i", "002@.0 =$ 'P1'"])
         .arg(data_dir().join("ada.dat"))
@@ -316,7 +314,7 @@ fn relation_ends_with() -> TestResult {
 
 #[test]
 fn relation_ends_not_with() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@.0 !$ 'sz'"])
         .arg(data_dir().join("ada.dat"))
@@ -328,7 +326,7 @@ fn relation_ends_not_with() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "002@{ 0 !$ 'sz' }"])
         .arg(data_dir().join("ada.dat"))
@@ -340,7 +338,7 @@ fn relation_ends_not_with() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ANY 028@.a !$ 'lace'"])
         .arg(data_dir().join("ada.dat"))
@@ -352,7 +350,7 @@ fn relation_ends_not_with() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ALL 028@.a !$ 'lace'"])
         .arg(data_dir().join("ada.dat"))
@@ -364,7 +362,7 @@ fn relation_ends_not_with() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i", "002@.0 !$ 'SZ'"])
         .arg(data_dir().join("ada.dat"))
@@ -381,7 +379,7 @@ fn relation_ends_not_with() -> TestResult {
 
 #[test]
 fn relation_similar() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028A.a =* 'LovelacE'"])
         .arg(data_dir().join("ada.dat"))
@@ -393,7 +391,7 @@ fn relation_similar() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028A{ a =* 'LovelacE' }"])
         .arg(data_dir().join("ada.dat"))
@@ -405,7 +403,7 @@ fn relation_similar() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ANY 028@.a =* 'LovelacE'"])
         .arg(data_dir().join("ada.dat"))
@@ -417,7 +415,7 @@ fn relation_similar() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ALL 028@.a =* 'Hatelace'"])
         .arg(data_dir().join("ada.dat"))
@@ -429,7 +427,7 @@ fn relation_similar() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i", "028A.a =* 'lOVELACe'"])
         .arg(data_dir().join("ada.dat"))
@@ -445,7 +443,7 @@ fn relation_similar() -> TestResult {
 
 #[test]
 fn relation_contains() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028A.a =? 'ove'"])
         .arg(data_dir().join("ada.dat"))
@@ -457,7 +455,7 @@ fn relation_contains() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "028A{ a =? 'ove' }"])
         .arg(data_dir().join("ada.dat"))
@@ -469,7 +467,7 @@ fn relation_contains() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ANY 028@.a =? 'ove'"])
         .arg(data_dir().join("ada.dat"))
@@ -481,7 +479,7 @@ fn relation_contains() -> TestResult {
         .stdout(predicates::path::eq_file(data_dir().join("ada.dat")))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "ALL 028@.a =? 'ove'"])
         .arg(data_dir().join("ada.dat"))
@@ -493,7 +491,7 @@ fn relation_contains() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["filter", "-i", "028A.a =? 'OVE'"])
         .arg(data_dir().join("ada.dat"))

--- a/crates/pica-cli/tests/frequency/mod.rs
+++ b/crates/pica-cli/tests/frequency/mod.rs
@@ -1,6 +1,5 @@
 use std::fs::read_to_string;
 
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -8,7 +7,7 @@ use crate::prelude::*;
 
 #[test]
 fn frequency_stdout() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-s", "002@.0"])
         .arg(data_dir().join("algebra.dat"))
@@ -28,7 +27,7 @@ fn frequency_stdout() -> TestResult {
 
 #[test]
 fn frequency_alias() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["freq", "-s", "002@.0"])
         .arg(data_dir().join("algebra.dat"))
@@ -48,7 +47,7 @@ fn frequency_alias() -> TestResult {
 
 #[test]
 fn frequency_output() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("freqs.csv");
 
@@ -75,7 +74,7 @@ fn frequency_output() -> TestResult {
 
 #[test]
 fn frequency_skip_invalid() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "002@.0"])
         .arg(data_dir().join("invalid.dat"))
@@ -89,7 +88,7 @@ fn frequency_skip_invalid() -> TestResult {
             "parse error: invalid record on line 1",
         ));
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-s", "002@.0"])
         .arg(data_dir().join("invalid.dat"))
@@ -106,7 +105,7 @@ fn frequency_skip_invalid() -> TestResult {
 
 #[test]
 fn frequency_unique() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "012A.0"])
         .write_stdin(
@@ -120,7 +119,7 @@ fn frequency_unique() -> TestResult {
         .stdout(predicates::ord::eq("abc,2\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "--unique", "012A.0"])
         .write_stdin(
@@ -139,7 +138,7 @@ fn frequency_unique() -> TestResult {
 
 #[test]
 fn frequency_reverse() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-r", "002@.0"])
         .arg(data_dir().join("algebra.dat"))
@@ -158,7 +157,7 @@ fn frequency_reverse() -> TestResult {
 
 #[test]
 fn frequency_num() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-s", "-n", "2", "002@.0"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -175,7 +174,7 @@ fn frequency_num() -> TestResult {
 
 #[test]
 fn frequency_limit() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-l", "1", "002@.0"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -192,7 +191,7 @@ fn frequency_limit() -> TestResult {
 
 #[test]
 fn frequency_threshold() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-s", "002@.0"])
         .args(["--threshold", "2"])
@@ -210,7 +209,7 @@ fn frequency_threshold() -> TestResult {
 
 #[test]
 fn frequency_squash() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "008A.a"])
         .arg(data_dir().join("ada.dat"))
@@ -222,7 +221,7 @@ fn frequency_squash() -> TestResult {
         .stdout(predicates::ord::eq("f,1\ns,1\nz,1\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "--squash", "008A.a"])
         .arg(data_dir().join("ada.dat"))
@@ -239,7 +238,7 @@ fn frequency_squash() -> TestResult {
 
 #[test]
 fn frequency_merge() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "008[AB].a"])
         .arg(data_dir().join("ada.dat"))
@@ -251,7 +250,7 @@ fn frequency_merge() -> TestResult {
         .stdout(predicates::ord::eq("f,1\nk,1\ns,1\nv,1\nw,1\nz,1\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "--merge", "008[AB].a"])
         .arg(data_dir().join("ada.dat"))
@@ -268,7 +267,7 @@ fn frequency_merge() -> TestResult {
 
 #[test]
 fn frequency_where() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-s", "002@.0"])
         .args(["--where", "002@.0 =^ 'Ts'"])
@@ -287,7 +286,7 @@ fn frequency_where() -> TestResult {
 
 #[test]
 fn frequency_where_and() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-s", "002@.0"])
         .args(["--where", "002@.0 =^ 'T'"])
@@ -307,7 +306,7 @@ fn frequency_where_and() -> TestResult {
 
 #[test]
 fn frequency_where_or() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-s", "002@.0"])
         .args(["--where", "002@.0 =^ 'Ts'"])
@@ -328,7 +327,7 @@ fn frequency_where_or() -> TestResult {
 
 #[test]
 fn frequency_where_not() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-s", "002@.0"])
         .args(["--where", "002@.0 =^ 'T'"])
@@ -348,7 +347,7 @@ fn frequency_where_not() -> TestResult {
 
 #[test]
 fn frequency_where_and_not() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-s", "002@.0"])
         .args(["--where", "002@.0 =^ 'T'"])
@@ -369,7 +368,7 @@ fn frequency_where_and_not() -> TestResult {
 
 #[test]
 fn frequency_header() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-s", "002@.0"])
         .args(["--header", "bbg,cnt"])
@@ -385,7 +384,7 @@ fn frequency_header() -> TestResult {
         .stdout(predicates::ord::eq("bbg,cnt\nTp1,2\nTs1,1\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-s", "002@.0"])
         .args(["--header", "bbg, cnt"])
@@ -406,7 +405,7 @@ fn frequency_header() -> TestResult {
 
 #[test]
 fn frequency_tsv() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-s", "--tsv", "002@.0"])
         .arg(data_dir().join("algebra.dat"))
@@ -427,7 +426,7 @@ fn frequency_tsv() -> TestResult {
 #[test]
 fn frequency_translit() -> TestResult {
     // no translit
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "041@{ a | a =^ 'H'}"])
         .arg(data_dir().join("algebra.dat"))
@@ -440,7 +439,7 @@ fn frequency_translit() -> TestResult {
         .stderr(predicates::str::is_empty());
 
     // NFD
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "041@{ a | a =^ 'H'}"])
         .args(["--translit", "nfc"])
@@ -454,7 +453,7 @@ fn frequency_translit() -> TestResult {
         .stderr(predicates::str::is_empty());
 
     // NFKC
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "041@{ a | a =^ 'H'}"])
         .args(["--translit", "nfkc"])
@@ -468,7 +467,7 @@ fn frequency_translit() -> TestResult {
         .stderr(predicates::str::is_empty());
 
     // NFD
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "041@{ a | a =^ 'H'}"])
         .args(["--translit", "nfd"])
@@ -482,7 +481,7 @@ fn frequency_translit() -> TestResult {
         .stderr(predicates::str::is_empty());
 
     // NFKD
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "041@{ a | a =^ 'H'}"])
         .args(["--translit", "nfkd"])
@@ -502,7 +501,7 @@ fn frequency_translit() -> TestResult {
 fn frequency_allow() -> TestResult {
     // IDN
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let allow = temp_dir.child("allow.csv");
     allow.write_str("idn\n118540238\n040991970\n040991989\n")?;
 
@@ -522,7 +521,7 @@ fn frequency_allow() -> TestResult {
 
     // PPN
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let allow = temp_dir.child("allow.csv");
     allow.write_str("ppn\n118540238\n040991970\n040991989\n")?;
 
@@ -542,7 +541,7 @@ fn frequency_allow() -> TestResult {
 
     // PPN+IDN
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let allow = temp_dir.child("allow.csv");
     allow.write_str(
         "ppn,idn\n118540238,118607626\n040991970,040993396\n040991989,\n",)?;
@@ -567,7 +566,7 @@ fn frequency_allow() -> TestResult {
 fn frequency_deny() -> TestResult {
     // PPN
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let allow = temp_dir.child("deny.csv");
     allow.write_str("ppn\n040011569\n")?;
 
@@ -587,7 +586,7 @@ fn frequency_deny() -> TestResult {
 
     // IDN
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let allow = temp_dir.child("deny.csv");
     allow.write_str("idn\n040011569\n")?;
 
@@ -608,7 +607,7 @@ fn frequency_deny() -> TestResult {
 
     // IDN+PPN
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let allow = temp_dir.child("deny.csv");
     allow.write_str("idn,119232022\nppn\n040011569\n")?;
 

--- a/crates/pica-cli/tests/hash/mod.rs
+++ b/crates/pica-cli/tests/hash/mod.rs
@@ -1,4 +1,3 @@
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -20,7 +19,7 @@ const HASHES: &'static str = "\
 
 #[test]
 fn hash_single_record() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert =
         cmd.arg("hash").arg(data_dir().join("ada.dat")).assert();
 
@@ -38,7 +37,7 @@ fn hash_single_record() -> TestResult {
 
 #[test]
 fn hash_dump() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["hash", "-s"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -55,7 +54,7 @@ fn hash_dump() -> TestResult {
 
 #[test]
 fn hash_tsv() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["hash", "--tsv"])
         .arg(data_dir().join("ada.dat"))
@@ -75,7 +74,7 @@ fn hash_tsv() -> TestResult {
 
 #[test]
 fn hash_skip_invalid() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["hash", "-s"])
         .arg(data_dir().join("invalid.dat"))
@@ -87,7 +86,7 @@ fn hash_skip_invalid() -> TestResult {
         .stdout(predicates::ord::eq("ppn,hash\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert =
         cmd.arg("hash").arg(data_dir().join("invalid.dat")).assert();
 
@@ -104,7 +103,7 @@ fn hash_skip_invalid() -> TestResult {
 
 #[test]
 fn hash_header() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("hash")
         .args(["--header", "idn,sha256"])
@@ -125,7 +124,7 @@ fn hash_header() -> TestResult {
 
 #[test]
 fn hash_where() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["hash", "-s"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -143,7 +142,7 @@ fn hash_where() -> TestResult {
 
 #[test]
 fn hash_where_and() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["hash", "-s"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -162,7 +161,7 @@ fn hash_where_and() -> TestResult {
 
 #[test]
 fn hash_where_or() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["hash", "-s"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -183,7 +182,7 @@ fn hash_where_or() -> TestResult {
 
 #[test]
 fn hash_where_not() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["hash", "-s"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -202,7 +201,7 @@ fn hash_where_not() -> TestResult {
 
 #[test]
 fn hash_limit() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["hash", "-s", "-l", "2"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -221,7 +220,7 @@ fn hash_limit() -> TestResult {
 
 #[test]
 fn hash_allow() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
 
     let allow = temp_dir.child("ALLOW.csv");
@@ -246,7 +245,7 @@ fn hash_allow() -> TestResult {
 
 #[test]
 fn hash_deny() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
 
     let deny = temp_dir.child("DENY.csv");
@@ -279,7 +278,7 @@ fn hash_deny() -> TestResult {
 
 #[test]
 fn hash_filter_set_column() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
 
     let allow = temp_dir.child("ALLOW.csv");
@@ -305,7 +304,7 @@ fn hash_filter_set_column() -> TestResult {
 
 #[test]
 fn hash_filter_set_source() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
 
     let allow = temp_dir.child("ALLOW.csv");

--- a/crates/pica-cli/tests/invalid/mod.rs
+++ b/crates/pica-cli/tests/invalid/mod.rs
@@ -1,6 +1,5 @@
 use std::fs::read_to_string;
 
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
@@ -9,7 +8,7 @@ use crate::prelude::*;
 
 #[test]
 fn read_file_write_file() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.dat");
 
@@ -36,7 +35,7 @@ fn read_file_write_file() -> TestResult {
 
 #[test]
 fn read_stdin_write_file() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.dat");
 
@@ -63,7 +62,7 @@ fn read_stdin_write_file() -> TestResult {
 
 #[test]
 fn read_file_write_stdout() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let input = data_dir().join("invalid.dat");
 
     let assert = cmd.arg("invalid").arg(&input).assert();
@@ -78,7 +77,7 @@ fn read_file_write_stdout() -> TestResult {
 
 #[test]
 fn read_stdin_write_stdout() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let filename = data_dir().join("invalid.dat");
 
     let assert = cmd
@@ -97,7 +96,7 @@ fn read_stdin_write_stdout() -> TestResult {
 
 #[test]
 fn read_multiple_files() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let input = data_dir().join("invalid.dat");
 
     let assert = cmd
@@ -117,7 +116,7 @@ fn read_multiple_files() -> TestResult {
 
 #[test]
 fn read_gzip_file() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let input = data_dir().join("invalid.dat");
 
     let assert = cmd

--- a/crates/pica-cli/tests/partition/mod.rs
+++ b/crates/pica-cli/tests/partition/mod.rs
@@ -1,6 +1,5 @@
 use std::fs::read_to_string;
 
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
@@ -11,7 +10,7 @@ use crate::prelude::*;
 fn partition_by_bbg() -> TestResult {
     let outdir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["partition", "-s", "002@.0"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -24,7 +23,7 @@ fn partition_by_bbg() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("Tg1.dat"))
@@ -36,7 +35,7 @@ fn partition_by_bbg() -> TestResult {
         .stdout(predicates::ord::eq("1\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("Tu1.dat"))
@@ -55,7 +54,7 @@ fn partition_by_bbg() -> TestResult {
 fn partition_gzip() -> TestResult {
     let outdir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["partition", "-s", "--gzip", "002@.0"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -68,7 +67,7 @@ fn partition_gzip() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("Tp1.dat.gz"))
@@ -80,7 +79,7 @@ fn partition_gzip() -> TestResult {
         .stdout(predicates::ord::eq("1\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("Tu1.dat.gz"))
@@ -99,7 +98,7 @@ fn partition_gzip() -> TestResult {
 fn partition_template() -> TestResult {
     let outdir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["partition", "-s", "002@.0"])
         .args(["--template", "BBG_{}.dat"])
@@ -113,7 +112,7 @@ fn partition_template() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("BBG_Tg1.dat"))
@@ -125,7 +124,7 @@ fn partition_template() -> TestResult {
         .stdout(predicates::ord::eq("1\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("BBG_Tu1.dat"))
@@ -144,7 +143,7 @@ fn partition_template() -> TestResult {
 fn partition_stdin() -> TestResult {
     let outdir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["partition", "003@.0"])
         .args(["-o", outdir.to_str().unwrap()])
@@ -169,7 +168,7 @@ fn partition_stdin() -> TestResult {
 #[test]
 fn partition_skip_invalid() -> TestResult {
     let outdir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["partition", "003@.0"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -191,7 +190,7 @@ fn partition_skip_invalid() -> TestResult {
 #[test]
 fn multiple_partitions() -> TestResult {
     let outdir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["partition", "042A.a"])
         .arg(data_dir().join("ada.dat"))
@@ -219,7 +218,7 @@ fn multiple_partitions() -> TestResult {
 
 #[test]
 fn partition_where() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let outdir = TempDir::new().unwrap();
 
     let assert = cmd
@@ -237,7 +236,7 @@ fn partition_where() -> TestResult {
 
     assert_eq!(outdir.read_dir().unwrap().count(), 2);
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("Tp1.dat"))
@@ -256,7 +255,7 @@ fn partition_where() -> TestResult {
 
 #[test]
 fn partition_where_and() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let outdir = TempDir::new().unwrap();
 
     let assert = cmd
@@ -275,7 +274,7 @@ fn partition_where_and() -> TestResult {
 
     assert_eq!(outdir.read_dir().unwrap().count(), 1);
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("Tpz.dat"))
@@ -293,7 +292,7 @@ fn partition_where_and() -> TestResult {
 
 #[test]
 fn partition_and_or() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let outdir = TempDir::new().unwrap();
 
     let assert = cmd
@@ -312,7 +311,7 @@ fn partition_and_or() -> TestResult {
 
     assert_eq!(outdir.read_dir().unwrap().count(), 2);
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("Tp1.dat"))
@@ -331,7 +330,7 @@ fn partition_and_or() -> TestResult {
 
 #[test]
 fn partition_where_not() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let outdir = TempDir::new().unwrap();
 
     let assert = cmd
@@ -350,7 +349,7 @@ fn partition_where_not() -> TestResult {
 
     assert_eq!(outdir.read_dir().unwrap().count(), 1);
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("Tpz.dat"))
@@ -368,7 +367,7 @@ fn partition_where_not() -> TestResult {
 
 #[test]
 fn partition_allow() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let outdir = TempDir::new().unwrap();
 
@@ -390,7 +389,7 @@ fn partition_allow() -> TestResult {
 
     assert_eq!(outdir.read_dir().unwrap().count(), 2);
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("Tp1.dat"))
@@ -410,7 +409,7 @@ fn partition_allow() -> TestResult {
 
 #[test]
 fn partition_deny() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let outdir = TempDir::new().unwrap();
 
@@ -444,7 +443,7 @@ fn partition_deny() -> TestResult {
 
     assert_eq!(outdir.read_dir().unwrap().count(), 2);
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("Tp1.dat"))
@@ -464,7 +463,7 @@ fn partition_deny() -> TestResult {
 
 #[test]
 fn partition_filter_set_column() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let outdir = TempDir::new().unwrap();
 
@@ -487,7 +486,7 @@ fn partition_filter_set_column() -> TestResult {
 
     assert_eq!(outdir.read_dir().unwrap().count(), 2);
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("Tp1.dat"))
@@ -507,7 +506,7 @@ fn partition_filter_set_column() -> TestResult {
 
 #[test]
 fn partition_filter_set_source() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let outdir = TempDir::new().unwrap();
 
@@ -531,7 +530,7 @@ fn partition_filter_set_source() -> TestResult {
 
     assert_eq!(outdir.read_dir().unwrap().count(), 2);
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("Tp1.dat"))
@@ -551,7 +550,7 @@ fn partition_filter_set_source() -> TestResult {
 
 #[test]
 fn partition_limit() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let outdir = TempDir::new().unwrap();
 
     let assert = cmd
@@ -568,7 +567,7 @@ fn partition_limit() -> TestResult {
 
     assert_eq!(outdir.read_dir().unwrap().count(), 2);
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("Tp1.dat"))

--- a/crates/pica-cli/tests/prelude/mod.rs
+++ b/crates/pica-cli/tests/prelude/mod.rs
@@ -2,6 +2,8 @@ use std::env::current_dir;
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
+use assert_cmd::Command;
+
 pub(crate) type TestResult = anyhow::Result<()>;
 
 pub(crate) fn data_dir() -> &'static PathBuf {
@@ -15,4 +17,8 @@ pub(crate) fn data_dir() -> &'static PathBuf {
     });
 
     &DATA_DIR
+}
+
+pub(crate) fn pica_cmd() -> Command {
+    Command::new(assert_cmd::cargo::cargo_bin!("pica"))
 }

--- a/crates/pica-cli/tests/print/mod.rs
+++ b/crates/pica-cli/tests/print/mod.rs
@@ -1,6 +1,5 @@
 use std::fs::read_to_string;
 
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 use unicode_normalization::UnicodeNormalization;
@@ -9,7 +8,7 @@ use crate::prelude::*;
 
 #[test]
 fn print_stdout() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert =
         cmd.arg("print").arg(data_dir().join("ada.dat")).assert();
 
@@ -29,7 +28,7 @@ fn print_stdout() -> TestResult {
 
 #[test]
 fn print_output() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.txt");
 
@@ -62,7 +61,7 @@ fn print_limit() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.txt");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["print", "-l", "1"])
         .args(["-o", out.to_str().unwrap()])
@@ -90,7 +89,7 @@ fn print_limit() -> TestResult {
 
 #[test]
 fn print_where() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("print")
         .args(["--where", "003@.0 == \"119232022\""])
@@ -113,7 +112,7 @@ fn print_where() -> TestResult {
 
 #[test]
 fn print_where_and() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("print")
         .args(["--where", "003@.0 == \"119232022\""])
@@ -137,7 +136,7 @@ fn print_where_and() -> TestResult {
 
 #[test]
 fn print_where_and_not() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("print")
         .args(["--where", "003@.0 == \"119232022\""])
@@ -162,7 +161,7 @@ fn print_where_and_not() -> TestResult {
 
 #[test]
 fn print_where_or() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("print")
         .args(["--where", "003@.0 == \"119232023\""])
@@ -186,7 +185,7 @@ fn print_where_or() -> TestResult {
 
 #[test]
 fn print_where_not() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("print")
         .args(["--where", "003@.0 == \"119232022\""])
@@ -205,7 +204,7 @@ fn print_where_not() -> TestResult {
         .stdout(predicates::ord::eq(expected))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("print")
         .args(["--where", "003@.0 == \"119232022\""])
@@ -225,7 +224,7 @@ fn print_where_not() -> TestResult {
 #[test]
 fn print_allow() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("ppn\n119232022\n")?;
@@ -251,7 +250,7 @@ fn print_allow() -> TestResult {
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("xyz\n119232022\n")?;
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["print", "-A", allow.to_str().unwrap()])
         .args(["--filter-set-column", "xyz"])
@@ -274,7 +273,7 @@ fn print_allow() -> TestResult {
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("gnd_id\n119232022\n")?;
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["print", "-A", allow.to_str().unwrap()])
         .args(["--filter-set-column", "gnd_id"])
@@ -300,7 +299,7 @@ fn print_allow() -> TestResult {
 #[test]
 fn print_deny() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let deny = temp_dir.child("DENY.csv");
     deny.write_str("ppn\n040011569\n")?;
@@ -326,7 +325,7 @@ fn print_deny() -> TestResult {
     let deny = temp_dir.child("DENY.csv");
     deny.write_str("xyz\n040011569\n")?;
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["print", "-D", deny.to_str().unwrap()])
         .args(["--filter-set-column", "xyz"])
@@ -349,7 +348,7 @@ fn print_deny() -> TestResult {
     let deny = temp_dir.child("DENY.csv");
     deny.write_str("gnd_id\n4001156-2\n")?;
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["print", "-D", deny.to_str().unwrap()])
         .args(["--filter-set-column", "gnd_id"])
@@ -374,7 +373,7 @@ fn print_deny() -> TestResult {
 
 #[test]
 fn print_translit_nfc() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("print")
         .args(["--translit", "nfc"])
@@ -401,7 +400,7 @@ fn print_translit_nfc() -> TestResult {
 
 #[test]
 fn print_translit_nfkc() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("print")
         .args(["--translit", "nfkc"])
@@ -428,7 +427,7 @@ fn print_translit_nfkc() -> TestResult {
 
 #[test]
 fn print_translit_nfd() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("print")
         .args(["--translit", "nfd"])
@@ -455,7 +454,7 @@ fn print_translit_nfd() -> TestResult {
 
 #[test]
 fn print_translit_nfkd() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("print")
         .args(["--translit", "nfkd"])
@@ -482,7 +481,7 @@ fn print_translit_nfkd() -> TestResult {
 
 #[test]
 fn print_skip_invalid() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["print", "-s"])
         .arg(data_dir().join("invalid.dat"))
@@ -500,7 +499,7 @@ fn print_skip_invalid() -> TestResult {
         .stdout(predicates::ord::eq(expected))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["print"])
         .arg(data_dir().join("invalid.dat"))

--- a/crates/pica-cli/tests/sample/mod.rs
+++ b/crates/pica-cli/tests/sample/mod.rs
@@ -1,4 +1,3 @@
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
@@ -7,7 +6,7 @@ use crate::prelude::*;
 
 #[test]
 fn sample_stdout() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["sample", "1"])
         .arg(data_dir().join("ada.dat"))
@@ -27,7 +26,7 @@ fn sample_output() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let samples = temp_dir.child("samples.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["sample", "1"])
         .arg(data_dir().join("ada.dat"))
@@ -54,7 +53,7 @@ fn sample_gzip() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let samples = temp_dir.child("samples.dat.gz");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["sample", "2"])
         .arg(data_dir().join("ada.dat"))
@@ -67,7 +66,7 @@ fn sample_gzip() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(samples.to_str().unwrap())
@@ -85,7 +84,7 @@ fn sample_gzip() -> TestResult {
 
 #[test]
 fn sample_skip_invalid() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["sample", "-s", "10"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -97,7 +96,7 @@ fn sample_skip_invalid() -> TestResult {
         .stdout(predicates::str::is_empty().not())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["sample", "10"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -116,7 +115,7 @@ fn sample_skip_invalid() -> TestResult {
 
 #[test]
 fn sample_limit() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
 
     let samples = temp_dir.child("samples.dat");
@@ -133,7 +132,7 @@ fn sample_limit() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "--records"])
         .arg(samples.to_str().unwrap())
@@ -153,7 +152,7 @@ fn sample_seed() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let samples = temp_dir.child("samples.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["sample", "-s", "2"])
         .args(["--seed", "1234"])
@@ -181,7 +180,7 @@ fn sample_where() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let samples = temp_dir.child("samples.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["sample", "-s", "23"])
         .args(["--where", "003@.0 == '118540238'"])
@@ -209,7 +208,7 @@ fn sample_where_and() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let samples = temp_dir.child("samples.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["sample", "-s", "23"])
         .args(["--where", "002@.0 =^ 'Tp'"])
@@ -238,7 +237,7 @@ fn sample_where_not() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let samples = temp_dir.child("samples.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["sample", "-s", "23"])
         .args(["--where", "002@.0 =^ 'Tp'"])
@@ -267,7 +266,7 @@ fn sample_where_and_not() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let samples = temp_dir.child("samples.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["sample", "-s", "23"])
         .args(["--where", "002@.0 =^ 'Tp'"])
@@ -297,7 +296,7 @@ fn sample_where_or() -> TestResult {
     let temp_dir = TempDir::new().unwrap();
     let samples = temp_dir.child("samples.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["sample", "-s", "23"])
         .args(["--where", "003@.0 == '118515551'"])
@@ -329,7 +328,7 @@ fn sample_allow() -> TestResult {
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("idn\n118540238\n118515551\n")?;
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["sample", "-s", "10"])
         .args(["-A", allow.to_str().unwrap()])
@@ -374,7 +373,7 @@ fn sample_deny() -> TestResult {
     )
     .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["sample", "-s", "10"])
         .args(["-D", deny.to_str().unwrap()])

--- a/crates/pica-cli/tests/select/format.rs
+++ b/crates/pica-cli/tests/select/format.rs
@@ -1,10 +1,8 @@
-use assert_cmd::Command;
-
 use crate::prelude::*;
 
 #[test]
 fn format_string_simple() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("select")
         .arg("003@.0,028A{ a <$> (', ' d <*> ' (' c ')' ) }")
@@ -24,7 +22,7 @@ fn format_string_simple() -> TestResult {
 
 #[test]
 fn format_string_with_predicate() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("select")
         .arg("003@.0,028R{a <$> (', ' d <*> ' (' v ')') | v in ['Vater', 'Mutter']}")
@@ -45,7 +43,7 @@ fn format_string_with_predicate() -> TestResult {
 
 #[test]
 fn format_string_uppercase() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("select")
         .arg("003@.0,028A{?u a <$> (', ' d <*> ' (' c ')' ) }")
@@ -60,7 +58,7 @@ fn format_string_uppercase() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("select")
         .arg("003@.0,028A{?u a <$> (?u ', ' d <*> ' (' c ')' ) }")
@@ -80,7 +78,7 @@ fn format_string_uppercase() -> TestResult {
 
 #[test]
 fn format_string_lowercase() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("select")
         .arg("003@.0,028A{?l a <$> (', ' d <*> ' (' c ')' ) }")
@@ -95,7 +93,7 @@ fn format_string_lowercase() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("select")
         .arg("003@.0,028A{?l a <$> (?l ', ' d <*> ' (' c ')' ) }")
@@ -115,7 +113,7 @@ fn format_string_lowercase() -> TestResult {
 
 #[test]
 fn format_string_strip_whitespaces() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("select")
         .arg("003@.0,028A{ a <$> (?w ', ' d <*> ' (' c ')' ) }")
@@ -135,7 +133,7 @@ fn format_string_strip_whitespaces() -> TestResult {
 
 #[test]
 fn format_string_trim() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .arg("select")
         .arg("003@.0,028A{a <$> (?t ', ' d <*> ' (' c ') ' ) }")
@@ -155,7 +153,7 @@ fn format_string_trim() -> TestResult {
 
 #[test]
 fn format_strip_overread_char() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "021A{?o a }"])
         .write_stdin(b"021A \x1fa@abc\x1e\n")
@@ -167,7 +165,7 @@ fn format_strip_overread_char() -> TestResult {
         .stdout(predicates::ord::eq("abc\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "021A{ a }"])
         .write_stdin(b"021A \x1fa@abc\x1e\n")

--- a/crates/pica-cli/tests/select/mod.rs
+++ b/crates/pica-cli/tests/select/mod.rs
@@ -1,6 +1,5 @@
 use std::fs::read_to_string;
 
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -10,7 +9,7 @@ mod format;
 
 #[test]
 fn select_csv_stdout() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0,002@.0"])
         .arg(data_dir().join("algebra.dat"))
@@ -28,7 +27,7 @@ fn select_csv_stdout() -> TestResult {
 
 #[test]
 fn select_csv_output() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.csv");
 
@@ -56,7 +55,7 @@ fn select_csv_output() -> TestResult {
 
 #[test]
 fn select_tsv_stdout() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--tsv", "003@.0,002@.0"])
         .arg(data_dir().join("algebra.dat"))
@@ -74,7 +73,7 @@ fn select_tsv_stdout() -> TestResult {
 
 #[test]
 fn select_tsv_output() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let temp_dir = TempDir::new().unwrap();
     let out = temp_dir.child("out.tsv");
 
@@ -102,7 +101,7 @@ fn select_tsv_output() -> TestResult {
 
 #[test]
 fn select_stdin() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0,012B.0"])
         .write_stdin("003@ \x1f0123\x1e012B \x1f0bar\x1e\n")
@@ -114,7 +113,7 @@ fn select_stdin() -> TestResult {
         .stdout(predicates::ord::eq("123,bar\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "-s", "003@.0,012B.0"])
         .args([data_dir().join("invalid.dat"), "-".into()])
@@ -132,7 +131,7 @@ fn select_stdin() -> TestResult {
 
 #[test]
 fn select_skip_invalid() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "002@.0"])
         .arg(data_dir().join("invalid.dat"))
@@ -146,7 +145,7 @@ fn select_skip_invalid() -> TestResult {
             "parse error: invalid record on line 1",
         ));
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["frequency", "-s", "002@.0"])
         .arg(data_dir().join("invalid.dat"))
@@ -163,7 +162,7 @@ fn select_skip_invalid() -> TestResult {
 
 #[test]
 fn select_squash() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--squash", "003@.0,008A.a"])
         .arg(data_dir().join("math.dat.gz"))
@@ -175,7 +174,7 @@ fn select_squash() -> TestResult {
         .stdout(predicates::ord::eq("040379442,s|g\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0,008A.a"])
         .args(["--squash", "--separator", "+++"])
@@ -188,7 +187,7 @@ fn select_squash() -> TestResult {
         .stdout(predicates::ord::eq("040379442,s+++g\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0,008A.a"])
         .args(["--squash", "--separator", "s"])
@@ -208,7 +207,7 @@ fn select_squash() -> TestResult {
 
 #[test]
 fn select_merge() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--merge", "003@.0,008A.a,008B.a"])
         .arg(data_dir().join("algebra.dat"))
@@ -223,7 +222,7 @@ fn select_merge() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0,008A.a,008B.a"])
         .args(["--merge", "--separator", "+++"])
@@ -239,7 +238,7 @@ fn select_merge() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0,008A.a,008B.a"])
         .args(["--merge", "--separator", ""])
@@ -260,7 +259,7 @@ fn select_merge() -> TestResult {
 
 #[test]
 fn select_no_empty_columns() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--no-empty-columns", "003@.0,028A.a"])
         .arg(data_dir().join("algebra.dat"))
@@ -278,7 +277,7 @@ fn select_no_empty_columns() -> TestResult {
 
 #[test]
 fn select_unique() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--unique", "004B.a"])
         .arg(data_dir().join("math.dat.gz"))
@@ -297,7 +296,7 @@ fn select_unique() -> TestResult {
 
 #[test]
 fn select_ignore_case() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--ignore-case"])
         .args(["003@.0,041[A@]{ a | a == 'algebra'}"])
@@ -315,7 +314,7 @@ fn select_ignore_case() -> TestResult {
 
 #[test]
 fn select_strsim_threshold() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0,041[AP]{ a | a =* 'Algebra'}"])
         .arg(data_dir().join("algebra.dat"))
@@ -329,7 +328,7 @@ fn select_strsim_threshold() -> TestResult {
         ))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--strsim-threshold", "60"])
         .arg("041[AP]{ a | a =* 'Algebra'}")
@@ -349,7 +348,7 @@ fn select_strsim_threshold() -> TestResult {
 
 #[test]
 fn select_limit() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--limit", "2", "003@.0,002@.0"])
         .arg(data_dir().join("math.dat.gz"))
@@ -363,7 +362,7 @@ fn select_limit() -> TestResult {
         .stdout(predicates::ord::eq("040379442,Tsz\n040011569,Ts1\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "-l", "1", "003@.0,002@.0"])
         .arg(data_dir().join("math.dat.gz"))
@@ -377,7 +376,7 @@ fn select_limit() -> TestResult {
         .stdout(predicates::ord::eq("040379442,Tsz\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--limit", "0", "003@.0,002@.0"])
         .arg(data_dir().join("math.dat.gz"))
@@ -398,7 +397,7 @@ fn select_limit() -> TestResult {
 
 #[test]
 fn select_translit() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "041@{ a | a =^ 'H'}"])
         .arg(data_dir().join("algebra.dat"))
@@ -411,7 +410,7 @@ fn select_translit() -> TestResult {
         .stderr(predicates::str::is_empty());
 
     // NFD
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--translit", "nfd", "041@{ a | a =^ 'H'}"])
         .arg(data_dir().join("algebra.dat"))
@@ -424,7 +423,7 @@ fn select_translit() -> TestResult {
         .stderr(predicates::str::is_empty());
 
     // NFKD
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--translit", "nfkd", "041@{ a | a =^ 'H'}"])
         .arg(data_dir().join("algebra.dat"))
@@ -437,7 +436,7 @@ fn select_translit() -> TestResult {
         .stderr(predicates::str::is_empty());
 
     // NFC
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--translit", "nfc", "041@{ a | a =^ 'H'}"])
         .arg(data_dir().join("algebra.dat"))
@@ -450,7 +449,7 @@ fn select_translit() -> TestResult {
         .stderr(predicates::str::is_empty());
 
     // NFKC
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--translit", "nfkc", "041@{ a | a =^ 'H'}"])
         .arg(data_dir().join("algebra.dat"))
@@ -467,7 +466,7 @@ fn select_translit() -> TestResult {
 
 #[test]
 fn select_where() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0,002@.0"])
         .args(["--where", "003@.0 != '040011569'"])
@@ -486,7 +485,7 @@ fn select_where() -> TestResult {
 
 #[test]
 fn select_where_and() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0,002@.0"])
         .args(["--where", "003@.0 != '040011569'"])
@@ -506,7 +505,7 @@ fn select_where_and() -> TestResult {
 
 #[test]
 fn select_where_not() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0,002@.0"])
         .args(["--where", "003@.0 != '040011569'"])
@@ -526,7 +525,7 @@ fn select_where_not() -> TestResult {
 
 #[test]
 fn select_where_and_not() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0,002@.0"])
         .args(["--where", "003@.0 != '040011569'"])
@@ -547,7 +546,7 @@ fn select_where_and_not() -> TestResult {
 
 #[test]
 fn select_where_or() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0,002@.0"])
         .args(["--where", "002@.0 == 'Ts1'"])
@@ -569,7 +568,7 @@ fn select_where_or() -> TestResult {
 fn select_allow() -> TestResult {
     // IDN
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let allow = temp_dir.child("allow.csv");
     allow.write_str("idn\n118540238\n040991970\n")?;
@@ -590,7 +589,7 @@ fn select_allow() -> TestResult {
 
     // PPN
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let allow = temp_dir.child("allow.csv");
     allow.write_str("ppn\n118540238\n040991970\n")?;
@@ -611,7 +610,7 @@ fn select_allow() -> TestResult {
 
     // PPN+IDN
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let allow = temp_dir.child("allow.csv");
     allow.write_str(
@@ -633,7 +632,7 @@ fn select_allow() -> TestResult {
     temp_dir.close().unwrap();
 
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     // FILTER SET COLUMN
     let allow = temp_dir.child("allow.csv");
@@ -661,7 +660,7 @@ fn select_allow() -> TestResult {
 fn select_deny() -> TestResult {
     // IDN
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let deny = temp_dir.child("deny.csv");
     deny.write_str("idn\n040011569\n")?;
@@ -683,7 +682,7 @@ fn select_deny() -> TestResult {
 
     // PPN
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let deny = temp_dir.child("deny.csv");
     deny.write_str("ppn\n040011569\n")?;
@@ -705,7 +704,7 @@ fn select_deny() -> TestResult {
 
     // PPN+IDN
     let temp_dir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
 
     let deny = temp_dir.child("deny.csv");
     deny.write_str("idn,ppn\n119232022,040011569\n")?;
@@ -729,7 +728,7 @@ fn select_deny() -> TestResult {
 
 #[test]
 fn select_query_const() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0, 'abc'"])
         .arg(data_dir().join("ada.dat"))
@@ -746,7 +745,7 @@ fn select_query_const() -> TestResult {
 
 #[test]
 fn select_query_path() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0,002@.0"])
         .arg(data_dir().join("ada.dat"))
@@ -758,7 +757,7 @@ fn select_query_path() -> TestResult {
         .stdout(predicates::ord::eq("119232022,Tp1\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0,028@{ (d, a) | 4 == 'nafr'}"])
         .arg(data_dir().join("ada.dat"))
@@ -770,7 +769,7 @@ fn select_query_path() -> TestResult {
         .stdout(predicates::ord::eq("119232022,Ada Augusta,Byron\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--merge", "003@.0,008[AB].a"])
         .arg(data_dir().join("ada.dat"))
@@ -782,7 +781,7 @@ fn select_query_path() -> TestResult {
         .stdout(predicates::ord::eq("119232022,s|z|f|w|k|v\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "--squash", "003@.0, 008[AB].a"])
         .arg(data_dir().join("ada.dat"))
@@ -802,7 +801,7 @@ fn select_query_path() -> TestResult {
 #[test]
 #[cfg(feature = "compat")]
 fn select_compat() -> TestResult {
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@ $0,002@$0"])
         .arg(data_dir().join("algebra.dat"))
@@ -815,7 +814,7 @@ fn select_compat() -> TestResult {
         .stdout(predicates::ord::eq("040011569,Ts1\n119232022,Tp1\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@$0,028@{ $d, $a | $4 == 'nafr'}"])
         .arg(data_dir().join("ada.dat"))
@@ -827,7 +826,7 @@ fn select_compat() -> TestResult {
         .stdout(predicates::ord::eq("119232022,Ada Augusta,Byron\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@$0,028@{ ($d, $a) | $4 == 'nafr'}"])
         .arg(data_dir().join("ada.dat"))

--- a/crates/pica-cli/tests/slice/mod.rs
+++ b/crates/pica-cli/tests/slice/mod.rs
@@ -1,4 +1,3 @@
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 
@@ -9,7 +8,7 @@ fn slice_default() -> TestResult {
     let outdir = TempDir::new().unwrap();
     let out = outdir.child("slice.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["slice", "--skip-invalid"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -22,7 +21,7 @@ fn slice_default() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(out.to_str().unwrap())
@@ -43,7 +42,7 @@ fn slice_start_end() -> TestResult {
     let outdir = TempDir::new().unwrap();
     let out = outdir.child("slice.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["slice", "--skip-invalid"])
         .args(["--start", "2", "--end", "5"])
@@ -57,7 +56,7 @@ fn slice_start_end() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(out.to_str().unwrap())
@@ -78,7 +77,7 @@ fn slice_start() -> TestResult {
     let outdir = TempDir::new().unwrap();
     let out = outdir.child("slice.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["slice", "--skip-invalid"])
         .args(["--start", "9"])
@@ -92,7 +91,7 @@ fn slice_start() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(out.to_str().unwrap())
@@ -113,7 +112,7 @@ fn slice_end() -> TestResult {
     let outdir = TempDir::new().unwrap();
     let out = outdir.child("slice.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["slice", "--skip-invalid"])
         .args(["--end", "3"])
@@ -127,7 +126,7 @@ fn slice_end() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(out.to_str().unwrap())
@@ -148,7 +147,7 @@ fn slice_length() -> TestResult {
     let outdir = TempDir::new().unwrap();
     let out = outdir.child("slice.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["slice", "--skip-invalid"])
         .args(["--length", "5"])
@@ -162,7 +161,7 @@ fn slice_length() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(out.to_str().unwrap())
@@ -183,7 +182,7 @@ fn slice_gzip() -> TestResult {
     let outdir = TempDir::new().unwrap();
     let out = outdir.child("slice.dat.gz");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["slice", "--skip-invalid"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -196,7 +195,7 @@ fn slice_gzip() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(out.to_str().unwrap())
@@ -217,7 +216,7 @@ fn slice_append() -> TestResult {
     let outdir = TempDir::new().unwrap();
     let out = outdir.child("slice.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["slice", "--skip-invalid"])
         .args(["--length", "2"])
@@ -231,7 +230,7 @@ fn slice_append() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["slice", "--skip-invalid", "--append"])
         .args(["--start", "5", "--length", "2"])
@@ -245,7 +244,7 @@ fn slice_append() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(out.to_str().unwrap())
@@ -266,7 +265,7 @@ fn slice_skip_invalid() -> TestResult {
     let outdir = TempDir::new().unwrap();
     let out = outdir.child("slice.dat");
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["slice", "--skip-invalid"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -279,7 +278,7 @@ fn slice_skip_invalid() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(out.to_str().unwrap())
@@ -291,7 +290,7 @@ fn slice_skip_invalid() -> TestResult {
         .stdout(predicates::ord::eq("12\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["slice"])
         .arg(data_dir().join("DUMP.dat.gz"))

--- a/crates/pica-cli/tests/split/mod.rs
+++ b/crates/pica-cli/tests/split/mod.rs
@@ -1,4 +1,3 @@
-use assert_cmd::Command;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
@@ -9,7 +8,7 @@ use crate::prelude::*;
 fn split_default() -> TestResult {
     let outdir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["split", "-s", "100"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -22,7 +21,7 @@ fn split_default() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("0.dat"))
@@ -41,7 +40,7 @@ fn split_default() -> TestResult {
 fn split_size() -> TestResult {
     let outdir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["split", "-s", "2"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -84,7 +83,7 @@ fn split_size() -> TestResult {
 fn split_skip_invalid() -> TestResult {
     let outdir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["split", "-s", "5"])
         .arg(data_dir().join("invalid.dat"))
@@ -105,7 +104,7 @@ fn split_skip_invalid() -> TestResult {
     outdir.close().unwrap();
 
     let outdir = TempDir::new().unwrap();
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["split", "10"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -128,7 +127,7 @@ fn split_skip_invalid() -> TestResult {
 fn split_gzip() -> TestResult {
     let outdir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["split", "-s", "--gzip", "100"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -141,7 +140,7 @@ fn split_gzip() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("0.dat.gz"))
@@ -160,7 +159,7 @@ fn split_gzip() -> TestResult {
 fn split_template() -> TestResult {
     let outdir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["split", "-s", "5"])
         .args(["--template", "FOO_{}.dat"])
@@ -175,7 +174,7 @@ fn split_template() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("FOO_0.dat"))
@@ -187,7 +186,7 @@ fn split_template() -> TestResult {
         .stdout(predicates::ord::eq("5\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("FOO_1.dat"))
@@ -199,7 +198,7 @@ fn split_template() -> TestResult {
         .stdout(predicates::ord::eq("5\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["count", "-s", "--records"])
         .arg(outdir.join("FOO_2.dat"))
@@ -219,7 +218,7 @@ fn split_template() -> TestResult {
 fn split_where() -> TestResult {
     let outdir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["split", "-s", "100"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -233,7 +232,7 @@ fn split_where() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0"])
         .arg(outdir.join("0.dat"))
@@ -252,7 +251,7 @@ fn split_where() -> TestResult {
 fn split_where_and() -> TestResult {
     let outdir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["split", "-s", "100"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -267,7 +266,7 @@ fn split_where_and() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0"])
         .arg(outdir.join("0.dat"))
@@ -286,7 +285,7 @@ fn split_where_and() -> TestResult {
 fn split_where_not() -> TestResult {
     let outdir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["split", "-s", "100"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -301,7 +300,7 @@ fn split_where_not() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0"])
         .arg(outdir.join("0.dat"))
@@ -320,7 +319,7 @@ fn split_where_not() -> TestResult {
 fn split_where_and_not() -> TestResult {
     let outdir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["split", "-s", "100"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -336,7 +335,7 @@ fn split_where_and_not() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0"])
         .arg(outdir.join("0.dat"))
@@ -355,7 +354,7 @@ fn split_where_and_not() -> TestResult {
 fn split_where_or() -> TestResult {
     let outdir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["split", "-s", "1"])
         .arg(data_dir().join("DUMP.dat.gz"))
@@ -370,7 +369,7 @@ fn split_where_or() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0"])
         .arg(outdir.join("0.dat"))
@@ -382,7 +381,7 @@ fn split_where_or() -> TestResult {
         .stdout(predicates::ord::eq("040309606\n"))
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0"])
         .arg(outdir.join("1.dat"))
@@ -405,7 +404,7 @@ fn split_allow() -> TestResult {
     let allow = temp_dir.child("ALLOW.csv");
     allow.write_str("idn\n118540238\n118515551\n")?;
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["split", "-s", "10"])
         .args(["-A", allow.to_str().unwrap()])
@@ -419,7 +418,7 @@ fn split_allow() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0"])
         .arg(outdir.join("0.dat"))
@@ -459,7 +458,7 @@ fn split_deny() -> TestResult {
     )
     .unwrap();
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["split", "-s", "10"])
         .args(["-D", deny.to_str().unwrap()])
@@ -473,7 +472,7 @@ fn split_deny() -> TestResult {
         .stdout(predicates::str::is_empty())
         .stderr(predicates::str::is_empty());
 
-    let mut cmd = Command::cargo_bin("pica")?;
+    let mut cmd = pica_cmd();
     let assert = cmd
         .args(["select", "003@.0"])
         .arg(outdir.join("0.dat"))


### PR DESCRIPTION
Replace deprecated `Command::cargo_bin("pica")` calls with the recommended `cargo_bin!` macro to ensure compatibility with custom cargo build directories.

Changes:
- Add `pica_cmd()` helper function in test prelude that uses `assert_cmd::cargo::cargo_bin!` macro
- Update all 36 test files to use the new helper function
- Remove redundant `use assert_cmd::Command` imports

This resolves the CI deprecation warning and improves compatibility with different build configurations.