### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ unstable = []
 [dependencies]
 bstr = { version = "1.12" }
 flate2 = { version = "1.1" }
-regex = { version = "1.11" }
+regex = { version = "1.12" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 sha2 = { version = "0.10" }
 smallvec = { version = "1.15" }
@@ -45,7 +45,7 @@ pica-record = { path = "./", features = ["serde"] }
 quickcheck = { version = "1.0" }
 quickcheck_macros = { version = "1.0" }
 serde_test = { version = "1.0" }
-tempfile = { version = "3.20" }
+tempfile = { version = "3.23" }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/pica-cli/Cargo.toml
+++ b/crates/pica-cli/Cargo.toml
@@ -18,7 +18,7 @@ unstable = ["pica-record/unstable"]
 bstr = { version = "1.12" }
 clap_complete = { version = "4.5" }
 clap = { version = "4.5", features = ["derive", "cargo", "wrap_help"] }
-csv = { version = "1.3" }
+csv = { version = "1.4" }
 directories = { version = "6.0" }
 flate2 = { version = "1.1" }
 hashbrown = { version = "0.16", features = ["serde"] }
@@ -28,7 +28,7 @@ pica-record = { path = "../../", features = ["serde"] }
 polars = { version = "0.51", features = ["ipc", "decompress", "lazy", "fmt"] }
 quick-xml = { version = "0.38" }
 rand = { version = "0.9" }
-regex = { version = "1.11" }
+regex = { version = "1.12" }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { version = "2.0" }
@@ -38,7 +38,7 @@ unicode-normalization = { version = "0.1" }
 
 [dev-dependencies]
 anyhow = { version = "1.0" }
-assert_cmd = { version = "2.0" }
+assert_cmd = { version = "2.1" }
 assert_fs = { version = "1.1" }
 predicates = { version = "3.1" }
 


### PR DESCRIPTION
- Bump `assert_cmd` to `2.1`
- Bump `csv` to `1.4`
- Bump `regex` to `1.12`
- Bump `tempfile` to `3.23`