### PR TITLE
Process filter lists in `.txt` format as ppn lists

### DIFF
--- a/crates/pica-cli/src/utils.rs
+++ b/crates/pica-cli/src/utils.rs
@@ -122,6 +122,17 @@ pub(crate) fn read_filter_list(
                 )
                 .try_into_reader_with_file_path(Some(path.into()))?
                 .finish()?
+        } else if path_str.ends_with("txt")
+            || path_str.ends_with("txt.gz")
+        {
+            let mut df = CsvReadOptions::default()
+                .with_has_header(false)
+                .with_infer_schema_length(Some(0))
+                .try_into_reader_with_file_path(Some(path.into()))?
+                .finish()?;
+
+            df.rename("column_1", "ppn".into())?;
+            df
         } else {
             CsvReadOptions::default()
                 .with_has_header(true)


### PR DESCRIPTION
This PR introduces filter lists in plain text format. These lists are interpreted as CSV lists without a header, whereby the first column is interpreted as the PPN column.

```
$ pica filter -A allow.txt '002@.0 in ["Oa","Oaf","Olfo"]' -o out.dat
$ pica filter -A allow.txt.gz '002@.0 in ["Oa","Oaf","Olfo"]' -o out.dat
$ pica filter -D deny.txt '002@.0 in ["Oa","Oaf","Olfo"]' -o out.dat
$ pica filter -D deny.txt.gz '002@.0 in ["Oa","Oaf","Olfo"]' -o out.dat
```