### PR TITLE
Add conversion from format `download` to `plus`

### DIFF
--- a/crates/pica-cli/src/commands/convert/download.rs
+++ b/crates/pica-cli/src/commands/convert/download.rs
@@ -1,0 +1,95 @@
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+use std::path::Path;
+
+use bstr::ByteSlice;
+use pica_record::io::{ReadPicaError, RecordsIter};
+use pica_record::{ByteRecord, StringRecord};
+
+pub(crate) struct DownloadReader {
+    inner: BufReader<File>,
+    buf: Vec<u8>,
+}
+
+impl DownloadReader {
+    pub(crate) fn from_path<P: AsRef<Path>>(
+        path: P,
+    ) -> io::Result<Self> {
+        let reader = File::open(path)?;
+
+        Ok(Self {
+            inner: BufReader::new(reader),
+            buf: Vec::new(),
+        })
+    }
+}
+
+impl RecordsIter for DownloadReader {
+    type ByteItem<'a>
+        = Result<ByteRecord<'a>, ReadPicaError>
+    where
+        Self: 'a;
+
+    type StringItem<'a>
+        = Result<StringRecord<'a>, ReadPicaError>
+    where
+        Self: 'a;
+
+    fn next_byte_record(&mut self) -> Option<Self::ByteItem<'_>> {
+        self.buf.clear();
+
+        match self.inner.read_until(b'\n', &mut self.buf) {
+            Err(e) => return Some(Err(ReadPicaError::from(e))),
+            Ok(0) => return None,
+            Ok(_) => {
+                if !self.buf.starts_with(b"SET:") {
+                    return Some(Err(ReadPicaError::Other(
+                        "expected line starting with phrase 'SET:'"
+                            .into(),
+                    )));
+                }
+
+                match self.inner.read_until(b'\n', &mut self.buf) {
+                    Err(e) => return Some(Err(ReadPicaError::from(e))),
+                    Ok(n) => {
+                        if n != 2 {
+                            return Some(Err(ReadPicaError::Other(
+                                "expected empty line".into(),
+                            )));
+                        }
+                    }
+                }
+
+                self.buf.clear();
+            }
+        }
+
+        loop {
+            match self.inner.read_until(b'\n', &mut self.buf) {
+                Err(e) => return Some(Err(ReadPicaError::from(e))),
+                Ok(n) => {
+                    if n == 2 {
+                        break;
+                    }
+                }
+            }
+        }
+
+        self.buf = self
+            .buf
+            .replace(b"\xc6\x92", b"\x1f")
+            .replace(b"\x0D\x0A", b"\x1E")
+            .replace(b"\x1E\x1E", b"\x1E\x0A");
+
+        match ByteRecord::from_bytes(&self.buf) {
+            Ok(record) => Some(Ok(record)),
+            Err(err) => Some(Err(ReadPicaError::Parse {
+                msg: "invalid record".into(),
+                err,
+            })),
+        }
+    }
+    fn next_string_record(&mut self) -> Option<Self::StringItem<'_>> {
+        todo!()
+    }
+}

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -18,6 +18,8 @@ pub enum ReadPicaError {
     Utf8 { msg: String, err: Utf8Error },
     #[error(transparent)]
     IO(#[from] std::io::Error),
+    #[error("other: {0}")]
+    Other(String),
 }
 
 impl ReadPicaError {


### PR DESCRIPTION
## Example

```
$ pica convert --from download --to plus ~/tmp/download.txt | pica count
records: 75
fields: 3845
subfields: 11028
```
### TODOs

- [ ] Add PPN field
- [ ] Add integration tests
- [ ] Cleanup Code

Closes #1021 