### PR TITLE
Fix `--not` documentation in `filter.rs`

### DIFF
--- a/crates/pica-cli/src/commands/filter.rs
+++ b/crates/pica-cli/src/commands/filter.rs
@@ -119,7 +119,7 @@ pub(crate) struct Filter {
     /// Connects the where clause with additional expressions using the
     /// logical NOT-operator (negation)
     ///
-    /// This option can't be combined with `--and` or `--or`.
+    /// This option can't be combined with `--or`.
     #[arg(long, conflicts_with = "or")]
     not: Vec<String>,
 


### PR DESCRIPTION
`--not` kann mit `--and` kombiniert werden, deshalb ist der Satz entsprechend zu kürzen.